### PR TITLE
Default basketline link

### DIFF
--- a/Api/Core/Queries/WiserInstallation/InsertInitialDataEcommerce.sql
+++ b/Api/Core/Queries/WiserInstallation/InsertInitialDataEcommerce.sql
@@ -155,6 +155,7 @@ INSERT IGNORE INTO `easy_objects` (typenr, `key`, `value`) VALUES (-1,'W2CHECKOU
 INSERT IGNORE INTO `wiser_entity`(`name`, `module_id`, `accepted_childtypes`, `icon`, `icon_add`, `dedicated_table_prefix`) VALUES ('basket', 5000, '', '', '','basket');
 INSERT IGNORE INTO `wiser_entity`(`name`, `module_id`, `accepted_childtypes`, `icon`, `icon_add`, `dedicated_table_prefix`) VALUES ('basketline', 5000, '', '', '','basket');
 INSERT IGNORE INTO `easy_objects` (typenr, `key`, `value`) VALUES (-1,'W2CHECKOUT_AutoClearBasketsOnThankYouPage',"true");
+INSERT INTO `wiser_link` (`type`, `destination_entity_type`, `connected_entity_type`, `name`, `show_in_tree_view`, `show_in_data_selector`, `relationship`, `duplication`, `use_item_parent_id`) VALUES (5002, 'basket', 'basketline', 'Shopping cart line', 0, 0, 'one-to-one', 'none', 1);
 
 -- ----------------------------
 -- Mailtemplate


### PR DESCRIPTION
Added query to the InsertInitialDataEcommerce query that sets a default
link between basket and basketline to ensure the parent_item_id column
is used instead of wiser_itemlink.