### PR TITLE
Templates module - query preview placement adjusted

### DIFF
--- a/FrontEnd/Modules/Templates/Css/Templates.css
+++ b/FrontEnd/Modules/Templates/Css/Templates.css
@@ -159,6 +159,7 @@
 .advanced-panel {
     display: flex;
     align-items: flex-start;
+    flex-wrap: wrap;
     transition: 200ms ease-in-out;
     max-height: 0;
     padding: 0;
@@ -188,6 +189,10 @@
 .advanced-panel .item-right {
     padding-left: 40px;
     padding-top: 15px;
+}
+
+.advanced-panel .item-full {
+    width: 100%;
 }
 
 .user-check-panel,

--- a/FrontEnd/Modules/Templates/Views/Templates/Partials/HtmlSettings.cshtml
+++ b/FrontEnd/Modules/Templates/Views/Templates/Partials/HtmlSettings.cshtml
@@ -116,7 +116,7 @@
     </div>
 </div>
 
-<div class="item">
+<div class="item item-full">
     <h4><label for="preLoadQuery">Pre-load query</label></h4>
     <textarea rows="10" cols="30" id="preLoadQuery" data-editor-type="text/x-mysql">@Model.PreLoadQuery</textarea>
     <div class="form-hint"><span>Deze query wordt 1 keer helemaal aan het begin uitgevoerd tijdens het laden van deze template. De resultaten van deze query kunnen dan op andere plekken in de template gebruikt worden met de prefix "template.". Als de query bijvoorbeeld een kolom "title" terruggeeft, dan kan de variabele "{template.title}" overal in de template gebruikt worden, inclusief dynamische componenten. Alleen de eerste regel van het resultaat van de query kan gebruikt worden.</span></div>


### PR DESCRIPTION
In de template-module is het query-veld (in het advanced-panel) onder de overige velden geplaatst, 100% breed.