### PR TITLE
Feature/visibility button grid based on role

### DIFF
--- a/Api/Modules/Items/Services/ItemsService.cs
+++ b/Api/Modules/Items/Services/ItemsService.cs
@@ -155,7 +155,7 @@ namespace Api.Modules.Items.Services
             pagedResult.TotalNumberOfPages = Convert.ToInt32(Math.Ceiling((decimal)pagedResult.TotalNumberOfRecords / pagedRequest.PageSize));
             pagedResult.PageNumber = pagedRequest.Page;
             pagedResult.PageSize = pagedRequest.PageSize;
-            
+
             var currentUrl = HttpContextHelpers.GetOriginalRequestUri(httpContextAccessor.HttpContext);
             if (pagedResult.TotalNumberOfPages > pagedRequest.Page)
             {
@@ -283,14 +283,14 @@ namespace Api.Modules.Items.Services
             {
                 throw new ArgumentNullException(nameof(encryptedParentId));
             }
-            
+
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             var itemId = await wiserCustomersService.DecryptValue<ulong>(encryptedId, identity);
             var parentId = await wiserCustomersService.DecryptValue<ulong>(encryptedParentId, identity);
             var username = IdentityHelpers.GetUserName(identity);
             var customer = await wiserCustomersService.GetSingleAsync(identity);
             var encryptionKey = customer.ModelObject.EncryptionKey;
-            
+
             WiserItemDuplicationResultModel result;
             try
             {
@@ -316,12 +316,12 @@ namespace Api.Modules.Items.Services
             {
                 throw new ArgumentNullException(nameof(encryptedId));
             }
-            
+
             try
             {
                 await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
                 await clientDatabaseConnection.BeginTransactionAsync();
-                
+
                 var originalItemId = await wiserCustomersService.DecryptValue<ulong>(encryptedId, identity);
                 var item = await wiserItemsService.GetItemDetailsAsync(originalItemId);
 
@@ -332,7 +332,7 @@ namespace Api.Modules.Items.Services
                         StatusCode = HttpStatusCode.NotFound
                     };
                 }
-                
+
                 var userId = IdentityHelpers.GetWiserUserId(identity);
                 var (success, _, userItemPermissions) = await wiserItemsService.CheckIfEntityActionIsPossibleAsync(item.Id, EntityActions.Update, userId, onlyCheckAccessRights: true, entityType: item.EntityType);
                 if (!success)
@@ -549,7 +549,7 @@ namespace Api.Modules.Items.Services
             var userId = IdentityHelpers.GetWiserUserId(identity);
             var username = IdentityHelpers.GetUserName(identity);
             var encryptionKey = customer.ModelObject.EncryptionKey;
-            
+
             ulong parentId = 0;
             if (!String.IsNullOrWhiteSpace(encryptedParentId))
             {
@@ -594,7 +594,7 @@ namespace Api.Modules.Items.Services
             {
                 throw new ArgumentNullException(nameof(encryptedId));
             }
-            
+
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             var userId = IdentityHelpers.GetWiserUserId(identity);
             var username = IdentityHelpers.GetUserName(identity);
@@ -611,7 +611,7 @@ namespace Api.Modules.Items.Services
 
             var customer = await wiserCustomersService.GetSingleAsync(identity);
             var encryptionKey = customer.ModelObject.EncryptionKey;
-            
+
             try
             {
                 item = await wiserItemsService.UpdateAsync(itemId, item, userId, username, encryptionKey);
@@ -628,7 +628,7 @@ namespace Api.Modules.Items.Services
 
             return new ServiceResult<WiserItemModel>(item);
         }
-        
+
         /// <inheritdoc />
         public async Task<ServiceResult<bool>> DeleteAsync(string encryptedId, ClaimsIdentity identity, bool undelete = false, string entityType = null)
         {
@@ -636,7 +636,7 @@ namespace Api.Modules.Items.Services
             {
                 throw new ArgumentNullException(nameof(encryptedId));
             }
-            
+
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             var userId = IdentityHelpers.GetWiserUserId(identity);
             var username = IdentityHelpers.GetUserName(identity);
@@ -645,7 +645,7 @@ namespace Api.Modules.Items.Services
             {
                 throw new ArgumentException("Id must be greater than zero.");
             }
-            
+
             try
             {
                 await wiserItemsService.DeleteAsync(itemId, undelete, username, userId, entityType: entityType);
@@ -673,7 +673,7 @@ namespace Api.Modules.Items.Services
             {
                 throw new ArgumentNullException(nameof(encryptedId));
             }
-            
+
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             var userId = IdentityHelpers.GetWiserUserId(identity);
             var username = IdentityHelpers.GetUserName(identity);
@@ -682,7 +682,7 @@ namespace Api.Modules.Items.Services
             {
                 throw new ArgumentException("Id must be greater than zero.");
             }
-            
+
             var (success, errorMessage, _) = await wiserItemsService.CheckIfEntityActionIsPossibleAsync(itemId, isNewItem ? EntityActions.Create : EntityActions.Update, IdentityHelpers.GetWiserUserId(identity), item);
             if (!success)
             {
@@ -693,7 +693,7 @@ namespace Api.Modules.Items.Services
                     StatusCode = HttpStatusCode.Forbidden
                 };
             }
-        
+
             if (String.IsNullOrWhiteSpace(item?.EntityType))
             {
                 var newItem = await wiserItemsService.GetItemDetailsAsync(itemId);
@@ -816,7 +816,7 @@ namespace Api.Modules.Items.Services
             actionQuery = actionQuery.ReplaceCaseInsensitive("{encryptedId}", encryptedId.ToMySqlSafeValue(false));
             actionQuery = actionQuery.ReplaceCaseInsensitive("'{itemId}'", "?itemId").ReplaceCaseInsensitive("{itemId}", "?itemId");
             actionQuery = apiReplacementsService.DoIdentityReplacements(actionQuery, identity, true);
-            
+
             detailsQuery = detailsQuery.ReplaceCaseInsensitive("{itemId:decrypt(true)}", "?itemId");
             detailsQuery = apiReplacementsService.DoIdentityReplacements(detailsQuery, identity, true);
 
@@ -955,7 +955,7 @@ namespace Api.Modules.Items.Services
                     ReasonPhrase = "Invalid item ID."
                 };
             }
-            
+
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             var (success, _, userItemPermissions) = await wiserItemsService.CheckIfEntityActionIsPossibleAsync(itemId, EntityActions.Read, IdentityHelpers.GetWiserUserId(identity), onlyCheckAccessRights: true, entityType: entityType);
 
@@ -971,7 +971,7 @@ namespace Api.Modules.Items.Services
             results.CanCreate = (userItemPermissions & AccessRights.Create) == AccessRights.Create;
             results.CanWrite = (userItemPermissions & AccessRights.Update) == AccessRights.Update;
             results.CanDelete = (userItemPermissions & AccessRights.Delete) == AccessRights.Delete;
-            
+
             clientDatabaseConnection.ClearParameters();
             clientDatabaseConnection.AddParameter("itemId", itemId);
             clientDatabaseConnection.AddParameter("userId", userId);
@@ -1045,7 +1045,7 @@ namespace Api.Modules.Items.Services
                                 GROUP BY id
                                 
                                 ORDER BY ordering";
-            
+
             // First check the normal wiser_item table.
             var dataTable = await clientDatabaseConnection.GetAsync(String.Format(query, ""));
 
@@ -1104,6 +1104,7 @@ namespace Api.Modules.Items.Services
                 var options = dataRow.Field<string>("options")?.ReplaceCaseInsensitive("{itemId}", itemId.ToString());
                 var optionsObject = JObject.Parse(String.IsNullOrWhiteSpace(options) ? "{}" : options);
 
+                //Manipulate customActions based on Role if necessary
                 if (fieldType == "sub-entities-grid")
                 {
                     if (optionsObject.ContainsKey("toolbar"))
@@ -1111,8 +1112,8 @@ namespace Api.Modules.Items.Services
                         var toolbar = optionsObject.Value<JObject>("toolbar");
                         if (toolbar.ContainsKey("customActions"))
                         {
-                            var customActions = toolbar.Value<JArray>("customActions").ToList();
-                           var deletedCustomActions = new List<JToken>();
+                            var customActions = toolbar.Value<JArray>("customActions");
+                            var deletedCustomActions = new List<JToken>();
                             foreach (var customAction in customActions)
                             {
                                 var rolesToken = customAction.SelectToken("roles"); ;
@@ -1161,7 +1162,7 @@ namespace Api.Modules.Items.Services
 
                 if (String.IsNullOrWhiteSpace(htmlTemplate))
                 {
-                    var nameWithoutMode = $"{fieldType}.html"; 
+                    var nameWithoutMode = $"{fieldType}.html";
                     var name = $"{fieldType}{(String.IsNullOrWhiteSpace(fieldMode) ? "" : $"-{fieldMode}")}.html";
 
                     if (!fieldTemplates.ContainsKey(name))
@@ -1305,28 +1306,28 @@ namespace Api.Modules.Items.Services
                         break;
 
                     case "qr":
-                    {
-                        var customQueryResult = await ExecuteCustomQueryAsync(encryptedId, propertyId, new Dictionary<string, object>(), await wiserCustomersService.EncryptValue("0", identity), identity, userId);
-                        var property = (JProperty)customQueryResult?.ModelObject?.OtherData?.FirstOrDefault()?.FirstOrDefault();
-                        if (!String.IsNullOrWhiteSpace(property?.Name))
                         {
-                            var size = 0;
-                            if (optionsObject.ContainsKey(WiserItemsService.SizeKey))
+                            var customQueryResult = await ExecuteCustomQueryAsync(encryptedId, propertyId, new Dictionary<string, object>(), await wiserCustomersService.EncryptValue("0", identity), identity, userId);
+                            var property = (JProperty)customQueryResult?.ModelObject?.OtherData?.FirstOrDefault()?.FirstOrDefault();
+                            if (!String.IsNullOrWhiteSpace(property?.Name))
                             {
-                                size = optionsObject[WiserItemsService.SizeKey].Value<int>();
+                                var size = 0;
+                                if (optionsObject.ContainsKey(WiserItemsService.SizeKey))
+                                {
+                                    size = optionsObject[WiserItemsService.SizeKey].Value<int>();
+                                }
+
+                                if (size <= 0)
+                                {
+                                    size = 250;
+                                }
+
+                                var url = property.Value.Value<string>() ?? "";
+                                value = $"{httpContextAccessor.HttpContext.Request.Scheme}://{httpContextAccessor.HttpContext.Request.Host.Value}/api/v3/barcodes/qr?text={Uri.EscapeDataString(url)}&size={size}";
                             }
 
-                            if (size <= 0)
-                            {
-                                size = 250;
-                            }
-
-                            var url = property.Value.Value<string>() ?? "";
-                            value = $"{httpContextAccessor.HttpContext.Request.Scheme}://{httpContextAccessor.HttpContext.Request.Host.Value}/api/v3/barcodes/qr?text={Uri.EscapeDataString(url)}&size={size}";
+                            break;
                         }
-
-                        break;
-                    }
                     case "htmleditor":
                         value = await wiserItemsService.ReplaceHtmlForViewingAsync(value);
                         longValue = await wiserItemsService.ReplaceHtmlForViewingAsync(longValue);
@@ -1336,26 +1337,26 @@ namespace Api.Modules.Items.Services
                         value = value.HtmlEncode();
                         break;
                     case "iframe":
-                    {
-                        if (String.IsNullOrWhiteSpace(defaultValue))
                         {
-                            break;
-                        }
+                            if (String.IsNullOrWhiteSpace(defaultValue))
+                            {
+                                break;
+                            }
 
-                        var customQueryResult = await ExecuteCustomQueryAsync(encryptedId, propertyId, new Dictionary<string, object>(), await wiserCustomersService.EncryptValue("0", identity), identity, userId);
-                        if (customQueryResult.ModelObject is not { Success: true })
-                        {
-                            break;
-                        }
+                            var customQueryResult = await ExecuteCustomQueryAsync(encryptedId, propertyId, new Dictionary<string, object>(), await wiserCustomersService.EncryptValue("0", identity), identity, userId);
+                            if (customQueryResult.ModelObject is not { Success: true })
+                            {
+                                break;
+                            }
 
-                        if (customQueryResult.ModelObject.OtherData.FirstOrDefault() is not JObject jObject)
-                        {
+                            if (customQueryResult.ModelObject.OtherData.FirstOrDefault() is not JObject jObject)
+                            {
+                                break;
+                            }
+
+                            value = stringReplacementsService.DoReplacements(defaultValue, jObject.ToObject<Dictionary<string, object>>());
                             break;
                         }
-                        
-                        value = stringReplacementsService.DoReplacements(defaultValue, jObject.ToObject<Dictionary<string, object>>());
-                        break;
-                    }
                 }
 
                 // Setup any extra CSS for the field.
@@ -1543,7 +1544,7 @@ namespace Api.Modules.Items.Services
             {
                 return new ServiceResult<ItemMetaDataModel>();
             }
-            
+
             var result = new ItemMetaDataModel
             {
                 CanRead = (userItemPermissions & AccessRights.Read) == AccessRights.Read,
@@ -1555,7 +1556,7 @@ namespace Api.Modules.Items.Services
             clientDatabaseConnection.ClearParameters();
             clientDatabaseConnection.AddParameter("itemId", itemId);
             clientDatabaseConnection.AddParameter("userId", userId);
-            
+
             var query = $@"SELECT
 	                        item.id,
                             item.original_item_id,
@@ -1602,7 +1603,7 @@ namespace Api.Modules.Items.Services
                 // If we get to this point, the item was found in the archive, which means it has been deleted.
                 result.Removed = true;
             }
-            
+
             result.Id = itemId;
             result.EncryptedId = encryptedId;
             result.OriginalItemId = await wiserCustomersService.EncryptValue(Convert.ToString(dataTable.Rows[0]["original_item_id"]), identity);
@@ -1616,7 +1617,7 @@ namespace Api.Modules.Items.Services
             result.ChangedOn = dataTable.Rows[0].Field<DateTime?>("changed_on");
             result.ChangedBy = dataTable.Rows[0].Field<string>("changed_by");
             result.EnableMultipleEnvironments = Convert.ToBoolean(dataTable.Rows[0]["enable_multiple_environments"]);
-            
+
             return new ServiceResult<ItemMetaDataModel>(result);
         }
 
@@ -1682,7 +1683,7 @@ namespace Api.Modules.Items.Services
             var result = await stringReplacementsService.DoAllReplacementsAsync(template, dataRow, removeUnknownVariables: false);
             return new ServiceResult<string>(result);
         }
-        
+
         /// <inheritdoc />
         public async Task<ServiceResult<List<EntityTypeModel>>> GetPossibleEntityTypesAsync(ulong itemId, ClaimsIdentity identity)
         {
@@ -1693,7 +1694,7 @@ namespace Api.Modules.Items.Services
                                                                     FROM {WiserTableNames.WiserEntity}
                                                                     GROUP BY name
                                                                     ORDER BY IFNULL(friendly_name, name) ASC");
-            
+
             var results = new List<EntityTypeModel>();
             if (dataTable.Rows.Count == 0)
             {
@@ -1737,7 +1738,7 @@ namespace Api.Modules.Items.Services
             clientDatabaseConnection.AddParameter("parentId", parentId);
             clientDatabaseConnection.AddParameter("linkType", linkType);
 
-            var moduleIdClause = moduleId <= 0 ? "" : "AND item.moduleid = ?moduleId"; 
+            var moduleIdClause = moduleId <= 0 ? "" : "AND item.moduleid = ?moduleId";
 
             // Fix the ordering of items, because when people import items, they often don't set the order number correctly.
             // So we do that first here, to make sure they're all set correctly, otherwise moving items to a different position in the tree view won't work properly.
@@ -1857,7 +1858,7 @@ namespace Api.Modules.Items.Services
                     Checked = Convert.ToInt32(dataRow["checked"]) > 0
                 });
             }
-            
+
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             clientDatabaseConnection.ClearParameters();
             clientDatabaseConnection.AddParameter("moduleId", moduleId);
@@ -1930,7 +1931,7 @@ namespace Api.Modules.Items.Services
                     AddItem(dataRow);
                 }
             }
-            
+
             // If there are no entities that use item_parent_id from wiser_item with the given parent, just return the results.
             if (parentId > 0)
             {
@@ -2100,7 +2101,7 @@ namespace Api.Modules.Items.Services
         /// <inheritdoc />
         public async Task<ServiceResult<bool>> MoveItemAsync(ClaimsIdentity identity, string encryptedSourceId, string encryptedDestinationId, string position, string encryptedSourceParentId, string encryptedDestinationParentId, string sourceEntityType, string destinationEntityType, int moduleId)
         {
-            if (String.IsNullOrWhiteSpace(encryptedSourceId) 
+            if (String.IsNullOrWhiteSpace(encryptedSourceId)
                 || String.IsNullOrWhiteSpace(encryptedDestinationId)
                 || String.IsNullOrWhiteSpace(position)
                 || String.IsNullOrWhiteSpace(encryptedSourceParentId)
@@ -2115,14 +2116,14 @@ namespace Api.Modules.Items.Services
                     ReasonPhrase = "The parameters encryptedSourceId, encryptedDestinationId, position, encryptedSourceParentId, encryptedDestinationParentId, sourceEntityType and destinationEntityType need to have a value"
                 };
             }
-            
+
             var customer = (await wiserCustomersService.GetSingleAsync(identity)).ModelObject;
             var sourceId = wiserCustomersService.DecryptValue<ulong>(encryptedSourceId, customer);
             var destinationId = wiserCustomersService.DecryptValue<ulong>(encryptedDestinationId, customer);
             var sourceParentId = wiserCustomersService.DecryptValue<ulong>(encryptedSourceParentId, customer);
             var destinationParentId = wiserCustomersService.DecryptValue<ulong>(encryptedDestinationParentId, customer);
             var userId = IdentityHelpers.GetWiserUserId(identity);
-            
+
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             var (success, errorMessage, _) = await wiserItemsService.CheckIfEntityActionIsPossibleAsync(sourceId, EntityActions.Update, userId, entityType: sourceEntityType);
             if (!success)
@@ -2294,7 +2295,7 @@ namespace Api.Modules.Items.Services
                 throw;
             }
         }
-        
+
         /// <inheritdoc />
         public async Task<ServiceResult<bool>> AddMultipleLinksAsync(ClaimsIdentity identity, List<string> encryptedSourceIds, List<string> encryptedDestinationIds, int linkType, string sourceEntityType = null)
         {
@@ -2304,7 +2305,7 @@ namespace Api.Modules.Items.Services
             var sourceIds = encryptedSourceIds.Select(x => wiserCustomersService.DecryptValue<ulong>(x, customer)).ToList();
             var tablePrefix = String.IsNullOrWhiteSpace(sourceEntityType) ? "" : await wiserItemsService.GetTablePrefixForEntityAsync(sourceEntityType);
             var linkTypeSettings = await wiserItemsService.GetLinkTypeSettingsAsync(linkType, sourceEntityType);
-            
+
             clientDatabaseConnection.ClearParameters();
             clientDatabaseConnection.AddParameter("linkType", linkType);
 
@@ -2340,7 +2341,7 @@ namespace Api.Modules.Items.Services
                 StatusCode = HttpStatusCode.NoContent
             };
         }
-        
+
         /// <inheritdoc />
         public async Task<ServiceResult<bool>> RemoveMultipleLinksAsync(ClaimsIdentity identity, List<string> encryptedSourceIds, List<string> encryptedDestinationIds, int linkType, string sourceEntityType = null)
         {
@@ -2353,7 +2354,7 @@ namespace Api.Modules.Items.Services
 
             clientDatabaseConnection.ClearParameters();
             clientDatabaseConnection.AddParameter("linkType", linkType);
-            
+
             string query;
             if (linkTypeSettings.UseItemParentId)
             {
@@ -2366,7 +2367,7 @@ namespace Api.Modules.Items.Services
                         ReasonPhrase = "Received more or less than 1 destination item ID for a link type that is set to use parent_item_id, this is not possible."
                     };
                 }
-                
+
                 query = $@"UPDATE {tablePrefix}{WiserTableNames.WiserItem} SET parent_item_id = 0 WHERE id IN ({String.Join(",", sourceIds)})";
             }
             else


### PR DESCRIPTION
Changes in GetItemHtmlAsync to manipulate customActions based on role.

Example required role in customAction:
```
{
    "text": "Testknop 123",
    "icon": "sln",
	"minSelectedRows": 2,
	"maxSelectedRows": 3,
    "actions": [
		{
            "type": "executeQuery",
            "queryId": 2
        },
		{
			"type": "openWindow",
			"itemId": "{itemId}"
		}],
		"roles": ["Admin"]
}
```
If the user has no role that is contained in this list, the customAction is removed from the list thus not rendered.