### PR TITLE
Data selector changes

### DIFF
--- a/Api/Modules/DataSelectors/Services/DataSelectorsService.cs
+++ b/Api/Modules/DataSelectors/Services/DataSelectorsService.cs
@@ -380,7 +380,7 @@ namespace Api.Modules.DataSelectors.Services
                 data.Settings.Insecure = false;
             }
 
-            var (itemsRequest, statusCode, error) = await gclDataSelectorsService.InitializeItemsRequestAsync(data);
+            var (itemsRequest, statusCode, error) = await gclDataSelectorsService.InitializeItemsRequestAsync(data, true);
             if (statusCode != HttpStatusCode.OK)
             {
                 return new ServiceResult<string>

--- a/FrontEnd/Modules/DataSelector/Scripts/Connection.js
+++ b/FrontEnd/Modules/DataSelector/Scripts/Connection.js
@@ -215,8 +215,6 @@
                 return;
             }
 
-            console.log("connectionBlock:", connectionBlock);
-
             let linkType;
             if (this.isMainConnection) {
                 linkType = this.dataSelector.selectedLinkType;
@@ -448,7 +446,7 @@
                     $(connectionBlock).remove();
                 } else {
                     if (connectionBlock === undefined || connectionBlock === null) {
-                        connectionBlock = this.dataSelector.addConnection(inputRow.get(0));
+                        connectionBlock = this.dataSelector.addConnection(inputRow.get(0)).container;
                         $(connectionBlock).data("linkedToPropertySelect", e.sender);
                     }
 

--- a/FrontEnd/Modules/DataSelector/Scripts/Connection.js
+++ b/FrontEnd/Modules/DataSelector/Scripts/Connection.js
@@ -204,12 +204,20 @@
             // Although it's also possible to use "[...response]", this JSON trick works better as it also clones deep properties.
             this.availableProperties = JSON.parse(JSON.stringify(response));
 
+            this.availableProperties.splice(4, 0, {
+                value: "item_ordering",
+                entityName: entityType,
+                displayName: "Ordering (van item)",
+                propertyName: "item_ordering",
+                languageCode: ""
+            });
+
             if (!this.isMainConnection) {
-                this.availableProperties.splice(4, 0, {
-                    value: "item_ordering",
+                this.availableProperties.splice(5, 0, {
+                    value: "link_ordering",
                     entityName: entityType,
-                    displayName: "Ordering",
-                    propertyName: "item_ordering",
+                    displayName: "Ordering (van koppeling)",
+                    propertyName: "link_ordering",
                     languageCode: ""
                 });
             }

--- a/FrontEnd/Modules/DataSelector/Scripts/Connection.js
+++ b/FrontEnd/Modules/DataSelector/Scripts/Connection.js
@@ -22,6 +22,14 @@
             $(this.container).data("connection", this);
         }
 
+        getPrefix() {
+            const parentConnection = this.parentContainer.closest(".connectionBlock");
+            if (parentConnection === null) {
+                return "main_";
+            }
+
+        }
+
         createHtml() {
             const block = $(document.getElementById("connectionTemplate").innerHTML);
             $(this.parentContainer).append(block);
@@ -195,6 +203,16 @@
             // Create clone of "response" so it doesn't use the reference value, but a completely new object.
             // Although it's also possible to use "[...response]", this JSON trick works better as it also clones deep properties.
             this.availableProperties = JSON.parse(JSON.stringify(response));
+
+            if (!this.isMainConnection) {
+                this.availableProperties.splice(4, 0, {
+                    value: "item_ordering",
+                    entityName: entityType,
+                    displayName: "Ordering",
+                    propertyName: "item_ordering",
+                    languageCode: ""
+                });
+            }
 
             // Create a "unique value" for every property, based on the normal value.
             // A few inputs use this, like the group by input, order by input, and having inputs.

--- a/FrontEnd/Modules/DataSelector/Scripts/DataSelector.js
+++ b/FrontEnd/Modules/DataSelector/Scripts/DataSelector.js
@@ -424,7 +424,7 @@ const moduleSettings = {
                 }
             }
 
-            // Update field aliases for items already in the data source.
+            /*// Update field aliases for items already in the data source.
             dataItems.forEach((dataItem) => {
                 const item = baseDataSource.find((property) => {
                     return property.entityName === dataItem.entityName && property[valueProperty] === dataItem[valueProperty];
@@ -433,7 +433,7 @@ const moduleSettings = {
                     console.log("item", item);
                     dataItem.set("fieldAlias", item.fieldAlias);
                 }
-            });
+            });*/
 
             // Determine items that need to be added. These are items that are in the new data source, but are not present in the widget.
             baseDataSource.filter((property) => {
@@ -527,7 +527,11 @@ const moduleSettings = {
             });
 
             if (alsoUpdateSortAndGroupingOptions) {
-                if (this.mainConnection) {
+                // Also update sorting options select and group by select, which use the same fields.
+                this.updateWidgetDataSource($("#sorting").getKendoMultiSelect(), this.selectedFields, true);
+                this.updateWidgetDataSource($("#groupBy").getKendoMultiSelect(), this.selectedFields, true);
+
+                /*if (this.mainConnection) {
                     const allProperties = this.#getAllProperties(this.mainConnection);
 
                     allProperties.forEach((dataItem) => {
@@ -543,7 +547,7 @@ const moduleSettings = {
                     // Also update sorting options select and group by select, which use the same fields.
                     this.updateWidgetDataSource($("#sorting").getKendoMultiSelect(), allProperties, true);
                     this.updateWidgetDataSource($("#groupBy").getKendoMultiSelect(), allProperties, true);
-                }
+                }*/
             }
         }
 

--- a/FrontEnd/Modules/DataSelector/Scripts/DataSelector.js
+++ b/FrontEnd/Modules/DataSelector/Scripts/DataSelector.js
@@ -313,7 +313,7 @@ const moduleSettings = {
             selectEntity.bind("change", () => {
                 this.selectedEntityType = selectEntity.value();
 
-                const connection = $(this.mainConnection).data("connection");
+                const connection = $(this.mainConnection.container).data("connection");
                 connection.updateAvailableProperties().then(() => {
                     // Update the data sources of the main scopes and field selection.
                     const connectionBlock = this.container.querySelector(".connectionBlock");
@@ -424,6 +424,17 @@ const moduleSettings = {
                 }
             }
 
+            // Update field aliases for items already in the data source.
+            dataItems.forEach((dataItem) => {
+                const item = baseDataSource.find((property) => {
+                    return property.entityName === dataItem.entityName && property[valueProperty] === dataItem[valueProperty];
+                });
+                if (item) {
+                    console.log("item", item);
+                    dataItem.set("fieldAlias", item.fieldAlias);
+                }
+            });
+
             // Determine items that need to be added. These are items that are in the new data source, but are not present in the widget.
             baseDataSource.filter((property) => {
                 const item = dataItems.filter((dataItem) => {
@@ -516,10 +527,36 @@ const moduleSettings = {
             });
 
             if (alsoUpdateSortAndGroupingOptions) {
-                // Also update sorting options select and group by select, which use the same fields.
-                this.updateWidgetDataSource($("#sorting").getKendoMultiSelect(), this.selectedFields, true);
-                this.updateWidgetDataSource($("#groupBy").getKendoMultiSelect(), this.selectedFields, true);
+                if (this.mainConnection) {
+                    const allProperties = this.#getAllProperties(this.mainConnection);
+
+                    allProperties.forEach((dataItem) => {
+                        const selectedField = this.selectedFields.filter((property) => {
+                            return property.entityName === dataItem.entityName && property.value === dataItem.value;
+                        });
+
+                        if (selectedField.length === 0 || !selectedField[0].fieldAlias) return;
+
+                        dataItem.fieldAlias = selectedField[0].fieldAlias;
+                    });
+
+                    // Also update sorting options select and group by select, which use the same fields.
+                    this.updateWidgetDataSource($("#sorting").getKendoMultiSelect(), allProperties, true);
+                    this.updateWidgetDataSource($("#groupBy").getKendoMultiSelect(), allProperties, true);
+                }
             }
+        }
+
+        #getAllProperties(connection) {
+            let allProperties = [];
+
+            // Starting from the main connection.
+            allProperties = allProperties.concat(connection.availableProperties);
+            connection.container.querySelectorAll("div.connectionBlock").forEach((container) => {
+                allProperties = allProperties.concat(this.#getAllProperties($(container).data("connection")));
+            });
+
+            return allProperties;
         }
 
         updateAvailableLinkTypes() {
@@ -569,7 +606,7 @@ const moduleSettings = {
         addConnection(parentContainer, isMainConnection = false) {
             const connection = new Connection(this, parentContainer, isMainConnection);
             connection.initialize();
-            return connection.container;
+            return connection;
         }
 
         initializeWindow() {

--- a/FrontEnd/Modules/DataSelector/Scripts/DataSelector.js
+++ b/FrontEnd/Modules/DataSelector/Scripts/DataSelector.js
@@ -424,17 +424,6 @@ const moduleSettings = {
                 }
             }
 
-            /*// Update field aliases for items already in the data source.
-            dataItems.forEach((dataItem) => {
-                const item = baseDataSource.find((property) => {
-                    return property.entityName === dataItem.entityName && property[valueProperty] === dataItem[valueProperty];
-                });
-                if (item) {
-                    console.log("item", item);
-                    dataItem.set("fieldAlias", item.fieldAlias);
-                }
-            });*/
-
             // Determine items that need to be added. These are items that are in the new data source, but are not present in the widget.
             baseDataSource.filter((property) => {
                 const item = dataItems.filter((dataItem) => {
@@ -530,37 +519,7 @@ const moduleSettings = {
                 // Also update sorting options select and group by select, which use the same fields.
                 this.updateWidgetDataSource($("#sorting").getKendoMultiSelect(), this.selectedFields, true);
                 this.updateWidgetDataSource($("#groupBy").getKendoMultiSelect(), this.selectedFields, true);
-
-                /*if (this.mainConnection) {
-                    const allProperties = this.#getAllProperties(this.mainConnection);
-
-                    allProperties.forEach((dataItem) => {
-                        const selectedField = this.selectedFields.filter((property) => {
-                            return property.entityName === dataItem.entityName && property.value === dataItem.value;
-                        });
-
-                        if (selectedField.length === 0 || !selectedField[0].fieldAlias) return;
-
-                        dataItem.fieldAlias = selectedField[0].fieldAlias;
-                    });
-
-                    // Also update sorting options select and group by select, which use the same fields.
-                    this.updateWidgetDataSource($("#sorting").getKendoMultiSelect(), allProperties, true);
-                    this.updateWidgetDataSource($("#groupBy").getKendoMultiSelect(), allProperties, true);
-                }*/
             }
-        }
-
-        #getAllProperties(connection) {
-            let allProperties = [];
-
-            // Starting from the main connection.
-            allProperties = allProperties.concat(connection.availableProperties);
-            connection.container.querySelectorAll("div.connectionBlock").forEach((container) => {
-                allProperties = allProperties.concat(this.#getAllProperties($(container).data("connection")));
-            });
-
-            return allProperties;
         }
 
         updateAvailableLinkTypes() {


### PR DESCRIPTION
Added support for two new default columns:

- `item_ordering`: Selects the `ordering` column from wiser_item.
- `link_ordering`: Selects the `ordering` column from wiser_itemlink (only works in child or parent connections).

Asana: https://app.asana.com/0/1201027711166952/1202126887494460