### PR TITLE
Updated import module entity properties

### DIFF
--- a/Api/Modules/Imports/Controllers/ImportsController.cs
+++ b/Api/Modules/Imports/Controllers/ImportsController.cs
@@ -96,5 +96,19 @@ namespace Api.Modules.Imports.Controllers
         {
             return (await importsService.DeleteLinksAsync((ClaimsIdentity)User.Identity, deleteLinksConfirms)).GetHttpResponseMessage();
         }
+
+        /// <summary>
+        /// Retrieves all properties of an entity that can be used in the import module and returns them as <see cref="EntityPropertyModel"/> objects.
+        /// </summary>
+        /// <param name="entityName">The name of the property whose properties will be retrieved.</param>
+        /// <param name="linkType">Optional link type, in case the properties should be retrieved by link type instead of entity name.</param>
+        /// <returns>A collection of <see cref="EntityPropertyModel"/> objects.</returns>
+        [HttpGet]
+        [Route("entity-properties")]
+        [ProducesResponseType(typeof(IEnumerable<EntityPropertyModel>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetEntityProperties(string entityName = null, int linkType = 0)
+        {
+            return (await importsService.GetEntityProperties((ClaimsIdentity)User.Identity, entityName, linkType)).GetHttpResponseMessage();
+        } 
     }
 }

--- a/Api/Modules/Imports/Interfaces/IImportsService.cs
+++ b/Api/Modules/Imports/Interfaces/IImportsService.cs
@@ -52,5 +52,14 @@ namespace Api.Modules.Imports.Interfaces
         /// <param name="deleteLinksConfirms">A collection of <see cref="DeleteLinksConfirmModel"/>s containing the information about the links to delete.</param>
         /// <returns>Returns true on success.</returns>
         Task<ServiceResult<bool>> DeleteLinksAsync(ClaimsIdentity identity, List<DeleteLinksConfirmModel> deleteLinksConfirms);
+
+        /// <summary>
+        /// Retrieves all properties of an entity that can be used in the import module and returns them as <see cref="EntityPropertyModel"/> objects.
+        /// </summary>
+        /// <param name="identity">The identity of the authenticated user.</param>
+        /// <param name="entityName">The name of the property whose properties will be retrieved.</param>
+        /// <param name="linkType">Optional link type, in case the properties should be retrieved by link type instead of entity name.</param>
+        /// <returns>A collection of <see cref="EntityPropertyModel"/> objects.</returns>
+        Task<ServiceResult<IEnumerable<EntityPropertyModel>>> GetEntityProperties(ClaimsIdentity identity, string entityName = null, int linkType = 0);
     }
 }

--- a/Api/Modules/Imports/Models/EntityPropertyModel.cs
+++ b/Api/Modules/Imports/Models/EntityPropertyModel.cs
@@ -1,0 +1,38 @@
+﻿namespace Api.Modules.Imports.Models;
+
+/// <summary>
+/// An entity property with the data needed by the import module.
+/// </summary>
+public class EntityPropertyModel
+{
+    /// <summary>
+    /// The display name of the property.
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// The property's key. 
+    /// </summary>
+    public string Value { get; set; }
+
+    /// <summary>
+    /// Gets or sets the language code for this property.
+    /// </summary>
+    public string LanguageCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the field represents an image upload.
+    /// </summary>
+    public bool IsImageField { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether multiple images are allowed for this property.
+    /// </summary>
+    public bool AllowMultipleImages { get; set; }
+
+    /// <summary>
+    /// Gets or sets the order of this field, which is used to decide which property will be chosen when multiple names match.
+    /// This is a combination of the 'ordering' field and 'id' field of the entity property.
+    /// </summary>
+    public string PropertyOrder { get; set; }
+}

--- a/Api/Modules/Templates/Services/TemplatesService.cs
+++ b/Api/Modules/Templates/Services/TemplatesService.cs
@@ -1617,31 +1617,6 @@ WHERE role.id = {role_id}");
                 TemplateQueryStrings.Add("DELETE_MODULE_RIGHT_ASSIGNMENT", @"DELETE FROM `wiser_system`.`wiser_permission`
 WHERE role_id = {role_id} AND module_id={module_id}");
 
-                TemplateQueryStrings.Add("IMPORTEXPORT_GET_ENTITY_PROPERTIES", @"SELECT property.`name`, property.`value`, property.languageCode, property.isImageField, property.allowMultipleImages
-FROM (
-    SELECT 'Item naam' AS `name`, 'itemTitle' AS `value`, '' AS languageCode, 0 AS isImageField, 0 AS allowMultipleImages, 0 AS baseOrder
-    FROM DUAL
-    WHERE '{entityName}' NOT LIKE '{%}' AND '{entityName}' <> ''
-    UNION
-    SELECT
-        CONCAT(
-            IF(display_name = '', property_name, display_name),
-            IF(
-                language_code <> '',
-                CONCAT(' (', language_code, ')'),
-                ''
-            )
-        ) AS `name`,
-        IF(property_name = '', display_name, property_name) AS `value`,
-        language_code AS languageCode,
-        inputtype = 'image-upload' AS isImageField,
-        IFNULL(JSON_UNQUOTE(JSON_EXTRACT(NULLIF(`options`, ''), '$.multiple')), 'true') = 'true' AS allowMultipleImages,
-        1 AS baseOrder
-    FROM wiser_entityproperty
-    WHERE entity_name = '{entityName}'
-    OR ('{linkType}' > 0 AND link_type = '{linkType}')
-    ORDER BY baseOrder, `name`
-) AS property");
                 TemplateQueryStrings.Add("GET_ROLE_RIGHTS", @"SELECT
 	properties.id AS `propertyId`,
 	properties.entity_name AS `entityName`,

--- a/FrontEnd/Modules/ImportExport/Scripts/Import.js
+++ b/FrontEnd/Modules/ImportExport/Scripts/Import.js
@@ -668,7 +668,7 @@ const importModuleSettings = {
 
                                     //Get properties of selected entity.
                                     const promiseResults = await Promise.all([
-                                        Wiser2.api({ url: `${this.settings.serviceRoot}/IMPORTEXPORT_GET_ENTITY_PROPERTIES?entityName=${encodeURIComponent(options.model.importTo)}` })
+                                        Wiser2.api({ url: `${this.settings.wiserApiRoot}imports/entity-properties?entityName=${encodeURIComponent(options.model.importTo)}` })
                                     ]);
                                     const propertiesOfEntity = promiseResults[0];
 
@@ -681,16 +681,21 @@ const importModuleSettings = {
                                         let columnName = dataItem.column.toLowerCase();
                                         let propertyMatchMade = false;
 
-                                        //Find a match for the column name on a property.
-                                        for (let i = 0; i < propertiesOfEntity.length; i++) {
-                                            //Set the values if a match with a property has been made.
-                                            if (columnName === propertiesOfEntity[i].name.toLowerCase() || columnName === propertiesOfEntity[i].value.toLowerCase()) {
-                                                dataItem.set("specName", propertiesOfEntity[i].name);
-                                                this.selectProperty(dataItem, propertiesOfEntity[i]);
-                                                propertyMatchMade = true;
-                                                break;
-                                            }
-                                        };
+                                        // Find matches for the column name on a property.
+                                        const matchingProperties = propertiesOfEntity.filter(prop => {
+                                            return prop.name.toLowerCase() === columnName || prop.value.toLowerCase() === columnName;
+                                        });
+                                        if (matchingProperties.length > 0) {
+                                            const sorted = matchingProperties.sort((a, b) => {
+                                                if (a.propertyOrder < b.propertyOrder) return -1;
+                                                if (a.propertyOrder > b.propertyOrder) return 1;
+                                                return 0;
+                                            });
+
+                                            dataItem.set("specName", sorted[0].name);
+                                            this.selectProperty(dataItem, sorted[0]);
+                                            propertyMatchMade = true;
+                                        }
 
                                         //If no match has been made reset all values (in case entity changed).
                                         if (!propertyMatchMade) {
@@ -722,7 +727,7 @@ const importModuleSettings = {
                                 optionLabel: "Kies een eigenschap",
                                 dataSource: {
                                     transport: {
-                                        read: `${this.settings.serviceRoot}/IMPORTEXPORT_GET_ENTITY_PROPERTIES?entityName=${encodeURIComponent(options.model.importTo)}`
+                                        read: `${this.settings.wiserApiRoot}imports/entity-properties?entityName=${encodeURIComponent(options.model.importTo)}`
                                     }
                                 },
                                 change: (e) => {
@@ -848,7 +853,7 @@ const importModuleSettings = {
                                 optionLabel: "Kies een eigenschap",
                                 dataSource: {
                                     transport: {
-                                        read: `${this.settings.serviceRoot}/IMPORTEXPORT_GET_ENTITY_PROPERTIES?linkType=${options.model.linkType}`
+                                        read: `${this.settings.wiserApiRoot}imports/entity-properties?linkType=${options.model.linkType}`
                                     }
                                 },
                                 change: (e) => {


### PR DESCRIPTION
Entity properties are now selected base on their order in Wiser instead of always alphabetically. The list is still ordered alphabetically though. Also refactored the 'get-entity-properties' call to use an endpoint of the Imports module instead of using the old query in the templates service.

Asana: https://app.asana.com/0/1201027711166952/1201421987974117