### PR TITLE
Fixed bug in HTML editor

### DIFF
--- a/Api/Modules/Items/FieldTemplates/HTMLeditor.html
+++ b/Api/Modules/Items/FieldTemplates/HTMLeditor.html
@@ -14,7 +14,7 @@
         </div>
         <div class="editorWindow">
             <div class="pane-content">
-                <textarea id="field_window_{propertyIdWithSuffix}" name="{propertyName}_{languageCode}" class="editor" rows="5" cols="30" {required} pattern="{pattern}">{default_value}</textarea>
+                <textarea id="field_window_{propertyIdWithSuffix}" name="{propertyName}_{languageCode}" class="editor skip-when-saving" rows="5" cols="30" {required} pattern="{pattern}">{default_value}</textarea>
             </div>
             <footer class="fixed clear">
                 <div class="actions">

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -54,7 +54,7 @@ export class Fields {
 
             // If we have no name attribute, then it's not an element that we need to use. 
             // It's probably a sub element of some Kendo component then.
-            if (!field.attr("name")) {
+            if (!field.attr("name") || field.hasClass("skip-when-saving")) {
                 return;
             }
 
@@ -95,7 +95,7 @@ export class Fields {
                 extraData.value = names;
                 results.push(extraData);
                 return;
-            } 
+            }
             
             if (kendoControlName) {
                 let kendoControl = field.data(kendoControlName);


### PR DESCRIPTION
When saving an item, it would always save the original value again.