### PR TITLE
Removed hard-coded app key for Pusher

### DIFF
--- a/FrontEnd/Core/Models/FrontEndSettings.cs
+++ b/FrontEnd/Core/Models/FrontEndSettings.cs
@@ -38,6 +38,11 @@ namespace FrontEnd.Core.Models
         public string ApiClientSecret { get; set; }
 
         /// <summary>
+        /// Gets or sets the app key for Pusher events.
+        /// </summary>
+        public string PusherAppKey { get; set; }
+
+        /// <summary>
         /// Gets or sets the token for Track JS. If you don't want to use Track JS, you can leave this empty and the script will not be loaded.
         /// </summary>
         public string TrackJsToken { get; set; }

--- a/FrontEnd/Modules/TaskAlerts/Scripts/TaskAlerts.js
+++ b/FrontEnd/Modules/TaskAlerts/Scripts/TaskAlerts.js
@@ -183,8 +183,13 @@ const moduleSettings = {
         }
 
         async registerPusherAndEventListeners() {
+            if (!this.settings.pusherAppKey) {
+                console.log("No pusher app key set. Task alerts will not receive new messages automatically.");
+                return;
+            }
+
             // Generate new pusher component
-            const pusher = new Pusher("81c3d15c9d95132050cc", {
+            const pusher = new Pusher(this.settings.pusherAppKey, {
                 cluster: "eu",
                 forceTLS: true
             });

--- a/FrontEnd/Modules/TaskAlerts/Views/TaskAlerts/Index.cshtml
+++ b/FrontEnd/Modules/TaskAlerts/Views/TaskAlerts/Index.cshtml
@@ -24,7 +24,8 @@
       data-api-client-id="@Model.Settings.ApiClientId"
       data-api-client-secret="@Model.Settings.ApiClientSecret"
       data-sub-domain="@Model.SubDomain"
-      data-track-js-token="@Model.Settings.TrackJsToken">
+      data-track-js-token="@Model.Settings.TrackJsToken"
+      data-pusher-app-key="@Model.Settings.PusherAppKey">
 
     <ul id="taskList">
         <li id="taskHistory">


### PR DESCRIPTION
The app key for Pusher was hard-coded in the TaskAlerts scripting. The key has been moved to the appsettings.