### PR TITLE
Added "SERVICES" to template types

### DIFF
--- a/FrontEnd/Modules/Templates/Scripts/Templates.js
+++ b/FrontEnd/Modules/Templates/Scripts/Templates.js
@@ -75,6 +75,7 @@ const moduleSettings = {
                 "DIRECTORY": 7,
                 "XML": 8,
                 "AIS": 8,
+                "SERVICES": 8,
                 "ROUTINES": 9
             });
 


### PR DESCRIPTION
The new default name of the folder for service configurations is "SERVICES" instead of "AIS", but since there was no property for "SERVICES", the template type for new configurations would be 0 instead of 8.