### PR TITLE
Always load and URL regex now disable each other

### DIFF
--- a/FrontEnd/Modules/Templates/Scripts/Templates.js
+++ b/FrontEnd/Modules/Templates/Scripts/Templates.js
@@ -773,7 +773,9 @@ const moduleSettings = {
                     }).then(async (response) =>  {
                         document.getElementById("developmentTab").innerHTML = response;
                         await this.initKendoDeploymentTab();
+                        this.updateAlwaysLoadAndUrlRegexAvailability();
                         this.bindDeployButtons(id);
+                        this.bindDevelopmentTabEvents();
                     })
                 );
 
@@ -1865,7 +1867,19 @@ const moduleSettings = {
                 });
             });
         }
-        
+
+        /**
+         * Binds events for inputs on the development tab.
+         */
+        bindDevelopmentTabEvents() {
+            const alwaysLoadCheckbox = document.getElementById("loadAlways");
+            const urlRegexInput = document.getElementById("urlRegex");
+            if (alwaysLoadCheckbox && urlRegexInput) {
+                alwaysLoadCheckbox.addEventListener("change", this.updateAlwaysLoadAndUrlRegexAvailability.bind(this));
+                urlRegexInput.addEventListener("input", this.updateAlwaysLoadAndUrlRegexAvailability.bind(this));
+            }
+        }
+
         bindDeploymentTabEvents() {
             document.getElementById("saveButton").addEventListener("click", this.saveTemplate.bind(this));
             document.getElementById("saveAndDeployToTestButton").addEventListener("click", this.saveTemplate.bind(this, true));
@@ -2448,6 +2462,27 @@ const moduleSettings = {
             const initialData = JSON.stringify(this.initialTemplateSettings);
             const currentData = JSON.stringify(this.getCurrentTemplateSettings());
             return initialData === currentData;
+        }
+
+        /**
+         * The "always load" checkbox and the "URL regex" input cannot be used at the same time.
+         * If one input is used, the other is disabled.
+         */
+        updateAlwaysLoadAndUrlRegexAvailability() {
+            const alwaysLoadCheckbox = document.getElementById("loadAlways");
+            const urlRegexInput = document.getElementById("urlRegex");
+            if (!alwaysLoadCheckbox || !urlRegexInput) {
+                return;
+            }
+
+            // URL regex input is disabled if the "always load" checkbox is checked.
+            urlRegexInput.disabled = alwaysLoadCheckbox.checked;
+            urlRegexInput.readOnly = alwaysLoadCheckbox.checked;
+
+            // The "always load" checkbox is disabled if the "URL regex" input has a value.
+            const urlRegexHasValue = urlRegexInput.value !== "";
+            alwaysLoadCheckbox.disabled = urlRegexHasValue;
+            alwaysLoadCheckbox.readOnly = urlRegexHasValue;
         }
     }
 


### PR DESCRIPTION
The "always load" checkbox and "URL regex" input cannot be used at the same time, so they now disable the other input when they're being used.

Asana: https://app.asana.com/0/1201027711166952/1202945552323329