### PR TITLE
Add settings to mark a HTML template as a partial.

### DIFF
--- a/Api/Modules/Templates/Models/Template/TemplateSettingsModel.cs
+++ b/Api/Modules/Templates/Models/Template/TemplateSettingsModel.cs
@@ -46,6 +46,7 @@ namespace Api.Modules.Templates.Models.Template
         public bool IsDefaultHeader { get; set; }
         public bool IsDefaultFooter { get; set; }
         public string DefaultHeaderFooterRegex { get; set; }
+        public bool IsPartial { get; set; }
 
         // Css/Scss/Js settings.
         public ResourceInsertModes InsertMode { get; set; }

--- a/Api/Modules/Templates/Services/DataLayer/HistoryDataService.cs
+++ b/Api/Modules/Templates/Services/DataLayer/HistoryDataService.cs
@@ -118,7 +118,8 @@ namespace Api.Modules.Templates.Services.DataLayer
                                                                 template.trigger_table_name,
                                                                 template.is_default_header,
                                                                 template.is_default_footer,
-                                                                template.default_header_footer_regex
+                                                                template.default_header_footer_regex,
+                                                                template.is_partial
                                                             FROM {WiserTableNames.WiserTemplate} AS template 
                                                             LEFT JOIN (SELECT linkedTemplate.template_id, template_name, template_type FROM {WiserTableNames.WiserTemplate} linkedTemplate WHERE linkedTemplate.removed = 0 GROUP BY template_id) AS linkedTemplates ON FIND_IN_SET(linkedTemplates.template_id, template.linked_templates)
                                                             WHERE template.template_id = ?templateId
@@ -179,7 +180,8 @@ namespace Api.Modules.Templates.Services.DataLayer
                     TriggerTableName = row.Field<string>("trigger_table_name"),
                     IsDefaultHeader = Convert.ToBoolean(row["is_default_header"]),
                     IsDefaultFooter = Convert.ToBoolean(row["is_default_footer"]),
-                    DefaultHeaderFooterRegex = row.Field<string>("default_header_footer_regex")
+                    DefaultHeaderFooterRegex = row.Field<string>("default_header_footer_regex"),
+                    IsPartial = Convert.ToBoolean(row["is_partial"])
                 };
                 
                 var loginRolesString = row.Field<string>("login_role");

--- a/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
+++ b/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
@@ -134,7 +134,8 @@ LIMIT 1");
     template.trigger_table_name,
     template.is_default_header,
     template.is_default_footer,
-    template.default_header_footer_regex
+    template.default_header_footer_regex,
+    is_partial
 FROM {WiserTableNames.WiserTemplate} AS template 
 WHERE template.template_id = ?templateId
 {publishedVersionWhere}
@@ -201,7 +202,8 @@ LIMIT 1");
                 TriggerTableName = dataTable.Rows[0].Field<string>("trigger_table_name"),
                 IsDefaultHeader = Convert.ToBoolean(dataTable.Rows[0]["is_default_header"]),
                 IsDefaultFooter = Convert.ToBoolean(dataTable.Rows[0]["is_default_footer"]),
-                DefaultHeaderFooterRegex = dataTable.Rows[0].Field<string>("default_header_footer_regex")
+                DefaultHeaderFooterRegex = dataTable.Rows[0].Field<string>("default_header_footer_regex"),
+                IsPartial = Convert.ToBoolean(dataTable.Rows[0]["is_partial"])
             };
 
             var loginRolesString = dataTable.Rows[0].Field<string>("login_role");
@@ -499,6 +501,7 @@ GROUP BY wdc.content_id");
             clientDatabaseConnection.AddParameter("isDefaultHeader", templateSettings.IsDefaultHeader);
             clientDatabaseConnection.AddParameter("isDefaultFooter", templateSettings.IsDefaultFooter);
             clientDatabaseConnection.AddParameter("defaultHeaderFooterRegex", templateSettings.DefaultHeaderFooterRegex);
+            clientDatabaseConnection.AddParameter("isPartial", templateSettings.IsPartial);
 
             var query = $@"SET @VersionNumber = (SELECT MAX(version)+1 FROM {WiserTableNames.WiserTemplate} WHERE template_id = ?templateId GROUP BY template_id);
 INSERT INTO {WiserTableNames.WiserTemplate} (
@@ -549,7 +552,8 @@ INSERT INTO {WiserTableNames.WiserTemplate} (
     trigger_event,
     trigger_table_name,
     is_default_header,
-    is_default_footer
+    is_default_footer,
+    is_partial
 ) 
 VALUES (
     ?name,
@@ -599,7 +603,8 @@ VALUES (
     ?triggerEvent,
     ?triggerTableName,
     ?isDefaultHeader,
-    ?isDefaultFooter
+    ?isDefaultFooter,
+    ?isPartial
 )";
             return await clientDatabaseConnection.ExecuteAsync(query);
         }

--- a/Api/Modules/Templates/Services/HistoryService.cs
+++ b/Api/Modules/Templates/Services/HistoryService.cs
@@ -194,6 +194,7 @@ namespace Api.Modules.Templates.Services
             CheckIfValuesMatchAndSaveChangesToHistoryModel("isDefaultHeader", newVersion.IsDefaultHeader, oldVersion.IsDefaultHeader, historyModel);
             CheckIfValuesMatchAndSaveChangesToHistoryModel("isDefaultFooter", newVersion.IsDefaultFooter, oldVersion.IsDefaultFooter, historyModel);
             CheckIfValuesMatchAndSaveChangesToHistoryModel("defaultHeaderFooterRegex", newVersion.DefaultHeaderFooterRegex, oldVersion.DefaultHeaderFooterRegex, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("isPartial", newVersion.IsPartial, oldVersion.IsPartial, historyModel);
 
             var oldLinkedTemplates = newVersion.LinkedTemplates.RawLinkList.Split(new [] { ',' }, StringSplitOptions.RemoveEmptyEntries);
             var newLinkedTemplates = oldVersion.LinkedTemplates.RawLinkList.Split(new [] { ',' }, StringSplitOptions.RemoveEmptyEntries);

--- a/FrontEnd/Modules/Templates/Views/Templates/Partials/HtmlSettings.cshtml
+++ b/FrontEnd/Modules/Templates/Views/Templates/Partials/HtmlSettings.cshtml
@@ -82,6 +82,16 @@
     <label class="checkbox" for="loginRequired">
         <span>Gebruiker moet ingelogd zijn om deze template te zien</span>
     </label>
+    
+    <input id="isPartial" name="isPartial" type="checkbox" @(Model.IsPartial ? "checked" : "") class="hidden" />
+    <label class="checkbox" for="isPartial">
+        <span>Is een partial template</span>
+    </label>
+    <div class="form-hint">
+        <span>
+            Wanneer aangevinkt wordt de ombouw nooit om de template gedaan wanneer deze wordt opgevraagd via een XHR call.
+        </span>
+    </div>
 
     <div class="user-check-panel">
         <div class="item" data-label-style="float" data-label-width="0">


### PR DESCRIPTION
Add functionality to mark an HTML template as a partial to ignore the header and footer template when requesting a template through an XHR call. Templates marked as partial no longer need to use "ombouw=false".

Combined with GCL pull request: https://github.com/happy-geeks/geeks-core-library/pull/242

https://app.asana.com/0/1200346761113317/1203257614129593/