### PR TITLE
Pusher changes for template connected users

### DIFF
--- a/Api/Modules/Pusher/Models/PusherMessageRequestModel.cs
+++ b/Api/Modules/Pusher/Models/PusherMessageRequestModel.cs
@@ -12,6 +12,11 @@
         public string Channel { get; set; }
 
         /// <summary>
+        /// Gets or sets the name of the event that Pusher will trigger.
+        /// </summary>
+        public string EventName { get; set; }
+
+        /// <summary>
         /// Gets or sets the event data of the message.
         /// </summary>
         public object EventData { get; set; }

--- a/Api/Modules/Pusher/Services/PusherService.cs
+++ b/Api/Modules/Pusher/Services/PusherService.cs
@@ -61,7 +61,7 @@ namespace Api.Modules.Pusher.Services
 
             if (String.IsNullOrWhiteSpace(data.Channel))
             {
-                data.Channel = "agendering";
+                data.Channel = "Wiser";
             }
 
             if (data.EventData == null)
@@ -82,10 +82,10 @@ namespace Api.Modules.Pusher.Services
             };
 
             // Global messages do not fire events for a specific user.
-            var eventName = data.IsGlobalMessage ? data.Channel : $"{data.Channel}_{pusherId}";
+            var eventName = !String.IsNullOrWhiteSpace(data.EventName) ? data.EventName : data.IsGlobalMessage ? data.Channel : $"{data.Channel}_{pusherId}";
 
             var pusher = new PusherServer.Pusher(apiSettings.PusherAppId, apiSettings.PusherAppKey, apiSettings.PusherAppSecret, options);
-            var result = await pusher.TriggerAsync("Wiser", eventName, data.EventData);
+            var result = await pusher.TriggerAsync(data.Channel, eventName, data.EventData);
             var success = (int)result.StatusCode >= 200 && (int)result.StatusCode < 300;
             return new ServiceResult<bool>(success)
             {

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -2274,7 +2274,7 @@ export class Fields {
                             contentType: "application/json",
                             data: JSON.stringify({
                                 userId: userId,
-                                channel: action.channel || "",
+                                channel: action.channel || "agendering",
                                 eventData: eventData || ""
                             })
                         });

--- a/FrontEnd/Modules/TaskAlerts/Scripts/TaskAlerts.js
+++ b/FrontEnd/Modules/TaskAlerts/Scripts/TaskAlerts.js
@@ -195,7 +195,7 @@ const moduleSettings = {
             });
 
             // Wiser update channel for pusher messages
-            const channel = pusher.subscribe("Wiser");
+            const channel = pusher.subscribe("agendering");
             channel.bind("update_event", (event) => {
                 console.log("Received message for `update_event`", event);
             });
@@ -204,7 +204,7 @@ const moduleSettings = {
             const eventId = await Wiser.api({ url: `${this.settings.wiserApiRoot}pusher/event-id` });
 
             // User update channel for pusher messages
-            channel.bind("agendering_" + eventId, (event) => {
+            channel.bind(`agendering_${eventId}`, (event) => {
                 $("#taskList li:not(#taskHistory)").remove(); // First remove all loaded tasks
 
                 console.log("Received message for pusher event `agendering`, for the logged-in user", event);
@@ -216,7 +216,7 @@ const moduleSettings = {
                 taskAlerts.loadTasks();
             });
 
-            console.log("New pusher element generated, and subscribed to the channel(s) `Wiser`");
+            console.log("New pusher element generated, and subscribed to the channel 'agendering'");
         }
 
         /**
@@ -416,7 +416,10 @@ const moduleSettings = {
                         url: `${this.settings.wiserApiRoot}pusher/message`,
                         method: "POST",
                         contentType: "application/json",
-                        data: JSON.stringify({ userId: userId })
+                        data: JSON.stringify({
+                            channel: "agendering",
+                            userId: userId
+                        })
                     });
 
                     created++;
@@ -483,7 +486,10 @@ const moduleSettings = {
                     url: `${this.settings.wiserApiRoot}pusher/message`,
                     method: "POST",
                     contentType: "application/json",
-                    data: JSON.stringify({ userId: this.editTaskUserSelect.value() })
+                    data: JSON.stringify({
+                        channel: "agendering",
+                        userId: this.editTaskUserSelect.value()
+                    })
                 });
 
                 // After updating the task, immediately close the form.


### PR DESCRIPTION
Changed the way Pusher works so the channel names and event names can actually be used the way they were intended to be used. This allows the `TemplateConnectedUsers` scripting to create a channel specific for the current sub-domain. Also changes some scripting in `TaskAlerts` and `Fields` so they don't break due to the Pusher changes.

Asana: https://app.asana.com/0/1201027711166952/1203521973607618