### PR TITLE
Show admin username in history

### DIFF
--- a/Api/Core/Helpers/IdentityHelpers.cs
+++ b/Api/Core/Helpers/IdentityHelpers.cs
@@ -107,6 +107,10 @@ namespace Api.Core.Helpers
             {
                 result = claimsIdentity?.Claims.FirstOrDefault(claim => claim.Type == ClaimTypes.Name)?.Value;
             }
+            else
+            {
+                result += " (Admin)";
+            }
 
             return result;
         }

--- a/Api/Core/Queries/WiserInstallation/CreateDedicatedItemTablesTriggers.sql
+++ b/Api/Core/Queries/WiserInstallation/CreateDedicatedItemTablesTriggers.sql
@@ -208,6 +208,11 @@ CREATE TRIGGER `{tablePrefix}FileInsert` AFTER INSERT ON `{tablePrefix}wiser_ite
             INSERT INTO wiser_history (action, tablename, item_id, changed_by, field, oldvalue, newvalue)
             VALUES ('UPDATE_FILE', '{tablePrefix}wiser_itemfile', NEW.id, IFNULL(@_username, USER()), 'property_name', NULL, NEW.property_name);
         END IF;
+
+        IF IFNULL(NEW.ordering, 0) <> 0 THEN
+            INSERT INTO wiser_history (action, tablename, item_id, changed_by, field, oldvalue, newvalue)
+            VALUES ('UPDATE_FILE', '{tablePrefix}wiser_itemfile', NEW.id, IFNULL(@_username, USER()), 'ordering', NULL, NEW.ordering);
+        END IF;
     END IF;
 END;
 
@@ -267,6 +272,11 @@ CREATE TRIGGER `{tablePrefix}FileUpdate` AFTER UPDATE ON `{tablePrefix}wiser_ite
         IF NEW.itemlink_id <> OLD.itemlink_id THEN
             INSERT INTO wiser_history (action, tablename, item_id, changed_by, field, oldvalue, newvalue)
             VALUES ('UPDATE_FILE', '{tablePrefix}wiser_itemfile', OLD.id, IFNULL(@_username, USER()), 'itemlink_id', OLD.itemlink_id, NEW.itemlink_id);
+        END IF;
+
+        IF NEW.ordering <> OLD.ordering THEN
+            INSERT INTO wiser_history (action, tablename, item_id, changed_by, field, oldvalue, newvalue)
+            VALUES ('UPDATE_FILE', '{tablePrefix}wiser_itemfile', OLD.id, IFNULL(@_username, USER()), 'ordering', OLD.ordering, NEW.ordering);
         END IF;
     END IF;
 END;

--- a/Api/Core/Queries/WiserInstallation/CreateTriggers.sql
+++ b/Api/Core/Queries/WiserInstallation/CreateTriggers.sql
@@ -759,6 +759,11 @@ CREATE TRIGGER `FileInsert` AFTER INSERT ON `wiser_itemfile` FOR EACH ROW BEGIN
             INSERT INTO wiser_history (action, tablename, item_id, changed_by, field, oldvalue, newvalue)
             VALUES ('UPDATE_FILE', 'wiser_itemfile', NEW.id, IFNULL(@_username, USER()), 'property_name', NULL, NEW.property_name);
         END IF;
+
+        IF IFNULL(NEW.ordering, 0) <> 0 THEN
+            INSERT INTO wiser_history (action, tablename, item_id, changed_by, field, oldvalue, newvalue)
+            VALUES ('UPDATE_FILE', 'wiser_itemfile', NEW.id, IFNULL(@_username, USER()), 'ordering', NULL, NEW.ordering);
+        END IF;
     END IF;
 END;
 
@@ -819,6 +824,11 @@ CREATE TRIGGER `FileUpdate` AFTER UPDATE ON `wiser_itemfile` FOR EACH ROW BEGIN
 			INSERT INTO wiser_history (action, tablename, item_id, changed_by, field, oldvalue, newvalue)
 			VALUES ('UPDATE_FILE', 'wiser_itemfile', OLD.id, IFNULL(@_username, USER()), 'itemlink_id', OLD.itemlink_id, NEW.itemlink_id);
 		END IF;
+
+        IF NEW.ordering <> OLD.ordering THEN
+            INSERT INTO wiser_history (action, tablename, item_id, changed_by, field, oldvalue, newvalue)
+            VALUES ('UPDATE_FILE', 'wiser_itemfile', OLD.id, IFNULL(@_username, USER()), 'ordering', OLD.ordering, NEW.ordering);
+        END IF;
     END IF;
 END;
 

--- a/Api/Core/Services/ApiReplacementsService.cs
+++ b/Api/Core/Services/ApiReplacementsService.cs
@@ -35,7 +35,7 @@ namespace Api.Core.Services
             {
                 { "userId", userId },
                 { "encryptedUserId", userId.ToString().EncryptWithAesWithSalt(withDateTime: true) },
-                { "username", IdentityHelpers.GetUserName(identity) },
+                { "username", IdentityHelpers.GetUserName(identity, true) },
                 { "userType", IdentityHelpers.GetRoles(identity) },
                 { "subDomain", IdentityHelpers.GetSubDomain(identity) },
                 { "isTest", IdentityHelpers.IsTestEnvironment(identity) }

--- a/Api/Modules/Files/Interfaces/IFilesService.cs
+++ b/Api/Modules/Files/Interfaces/IFilesService.cs
@@ -141,8 +141,9 @@ namespace Api.Modules.Files.Interfaces
         /// <param name="itemId">The ID of the item the files belong to.</param>
         /// <param name="itemLinkId">The ID of the link, if the files belong to an item link.</param>
         /// <param name="propertyName">The name of the property the files belong to.</param>
+        /// <param name="identity">The identity of the authenticated user.</param>
         /// <param name="entityType">Optional: When uploading a file for an item that has a dedicated table, enter the entity type name here so that we can see which table we need to add the file to.</param>
         /// <param name="linkType">Optional: When uploading a file for an item link that has a dedicated table, enter the link type here so that we can see which table we need to add the file to.</param>
-        Task FixOrderingAsync(ulong itemId, ulong itemLinkId, string propertyName, string entityType = null, int linkType = 0);
+        Task FixOrderingAsync(ulong itemId, ulong itemLinkId, string propertyName, ClaimsIdentity identity, string entityType = null, int linkType = 0);
     }
 }

--- a/Api/Modules/Grids/Services/GridsService.cs
+++ b/Api/Modules/Grids/Services/GridsService.cs
@@ -2432,7 +2432,7 @@ namespace Api.Modules.Grids.Services
 
             var userId = IdentityHelpers.GetWiserUserId(identity);
             query = query.ReplaceCaseInsensitive("{userId}", userId.ToString());
-            query = query.ReplaceCaseInsensitive("{username}", IdentityHelpers.GetUserName(identity) ?? "");
+            query = query.ReplaceCaseInsensitive("{username}", IdentityHelpers.GetUserName(identity, true) ?? "");
             query = query.ReplaceCaseInsensitive("{userEmailAddress}", IdentityHelpers.GetEmailAddress(identity) ?? "");
             query = query.ReplaceCaseInsensitive("{userType}", IdentityHelpers.GetRoles(identity) ?? "");
             query = query.ReplaceCaseInsensitive("{encryptedId}", encryptedId);

--- a/Api/Modules/Imports/Services/ImportsService.cs
+++ b/Api/Modules/Imports/Services/ImportsService.cs
@@ -173,7 +173,7 @@ namespace Api.Modules.Imports.Services
                         {
                             Item = new WiserItemModel
                             {
-                                ChangedBy = IdentityHelpers.GetUserName(identity),
+                                ChangedBy = IdentityHelpers.GetUserName(identity, true),
                                 ModuleId = moduleId
                             }
                         };
@@ -403,7 +403,7 @@ namespace Api.Modules.Imports.Services
                                         ItemId = importItem.Item.Id,
                                         FileName = Path.GetFileName(image.FilePath),
                                         Extension = Path.GetExtension(image.FilePath),
-                                        AddedBy = IdentityHelpers.GetUserName(identity),
+                                        AddedBy = IdentityHelpers.GetUserName(identity, true),
                                         PropertyName = image.PropertyName
                                     };
                                     importItem.Files.Add(itemFile);
@@ -560,7 +560,7 @@ namespace Api.Modules.Imports.Services
                 clientDatabaseConnection.ClearParameters();
                 clientDatabaseConnection.AddParameter("name", importRequest.Name);
                 clientDatabaseConnection.AddParameter("start_on", parsedDate);
-                clientDatabaseConnection.AddParameter("added_by", IdentityHelpers.GetUserName(identity));
+                clientDatabaseConnection.AddParameter("added_by", IdentityHelpers.GetUserName(identity, true));
                 clientDatabaseConnection.AddParameter("added_on", DateTime.Now);
                 clientDatabaseConnection.AddParameter("user_id", userId);
                 clientDatabaseConnection.AddParameter("customer_id", customer.CustomerId);
@@ -584,7 +584,7 @@ namespace Api.Modules.Imports.Services
                 clientDatabaseConnection.AddParameter("items_failed", importResult.Failed);
                 clientDatabaseConnection.AddParameter("errors", String.Join(Environment.NewLine, importResult.Errors));
                 clientDatabaseConnection.AddParameter("added_on", DateTime.Now);
-                clientDatabaseConnection.AddParameter("added_by", IdentityHelpers.GetUserName(identity));
+                clientDatabaseConnection.AddParameter("added_by", IdentityHelpers.GetUserName(identity, true));
                 await clientDatabaseConnection.InsertOrUpdateRecordBasedOnParametersAsync<int>(WiserTableNames.WiserImportLog);
             }
             catch (Exception exception)

--- a/Api/Modules/Items/Services/ItemsService.cs
+++ b/Api/Modules/Items/Services/ItemsService.cs
@@ -316,7 +316,7 @@ namespace Api.Modules.Items.Services
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             var itemId = await wiserCustomersService.DecryptValue<ulong>(encryptedId, identity);
             var parentId = await wiserCustomersService.DecryptValue<ulong>(encryptedParentId, identity);
-            var username = IdentityHelpers.GetUserName(identity);
+            var username = IdentityHelpers.GetUserName(identity, true);
             var customer = await wiserCustomersService.GetSingleAsync(identity);
             var encryptionKey = customer.ModelObject.EncryptionKey;
 
@@ -383,7 +383,7 @@ namespace Api.Modules.Items.Services
                 }
 
                 var tablePrefix = await wiserItemsService.GetTablePrefixForEntityAsync(item.EntityType);
-                var username = IdentityHelpers.GetUserName(identity);
+                var username = IdentityHelpers.GetUserName(identity, true);
                 var customer = await wiserCustomersService.GetSingleAsync(identity);
                 var encryptionKey = customer.ModelObject.EncryptionKey;
                 var allLinkSettings = await wiserItemsService.GetAllLinkTypeSettingsAsync();
@@ -615,7 +615,7 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             var customer = await wiserCustomersService.GetSingleAsync(identity);
             var userId = IdentityHelpers.GetWiserUserId(identity);
-            var username = IdentityHelpers.GetUserName(identity);
+            var username = IdentityHelpers.GetUserName(identity, true);
             var encryptionKey = customer.ModelObject.EncryptionKey;
 
             ulong parentId = 0;
@@ -664,7 +664,7 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
 
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             var userId = IdentityHelpers.GetWiserUserId(identity);
-            var username = IdentityHelpers.GetUserName(identity);
+            var username = IdentityHelpers.GetUserName(identity, true);
             var itemId = await wiserCustomersService.DecryptValue<ulong>(encryptedId, identity);
             if (itemId <= 0)
             {
@@ -712,7 +712,7 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
 
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             var userId = IdentityHelpers.GetWiserUserId(identity);
-            var username = IdentityHelpers.GetUserName(identity);
+            var username = IdentityHelpers.GetUserName(identity, true);
             var itemId = await wiserCustomersService.DecryptValue<ulong>(encryptedId, identity);
             if (itemId <= 0)
             {
@@ -756,7 +756,7 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
 
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             var userId = IdentityHelpers.GetWiserUserId(identity);
-            var username = IdentityHelpers.GetUserName(identity);
+            var username = IdentityHelpers.GetUserName(identity, true);
             var itemId = await wiserCustomersService.DecryptValue<ulong>(encryptedId, identity);
             if (itemId <= 0)
             {
@@ -854,7 +854,7 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
         {
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             var userId = IdentityHelpers.GetWiserUserId(identity);
-            var username = IdentityHelpers.GetUserName(identity);
+            var username = IdentityHelpers.GetUserName(identity, true);
             var userEmailAddress = IdentityHelpers.GetEmailAddress(identity);
             var userType = IdentityHelpers.GetRoles(identity);
             var queryId = await wiserCustomersService.DecryptValue<int>(encryptedQueryId, identity);
@@ -1310,7 +1310,7 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
                     filesJson = parsedFilesJson.ToString();
                     
                     // Fix the ordering of the files in this field, to prevent problems with changing the ordering later.
-                    await filesService.FixOrderingAsync(itemId, itemLinkId, propertyName);
+                    await filesService.FixOrderingAsync(itemId, itemLinkId, propertyName, identity);
                 }
 
                 var extraAttributes = "";
@@ -2554,7 +2554,7 @@ ORDER BY {orderByClause}";
             
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             var itemId = await wiserCustomersService.DecryptValue<ulong>(encryptedId, identity);
-            var username = IdentityHelpers.GetUserName(identity);
+            var username = IdentityHelpers.GetUserName(identity, true);
             var userId = IdentityHelpers.GetWiserUserId(identity);
             var customer = await wiserCustomersService.GetSingleAsync(identity);
             var encryptionKey = customer.ModelObject.EncryptionKey;

--- a/Api/Modules/Modules/Services/ModulesService.cs
+++ b/Api/Modules/Modules/Services/ModulesService.cs
@@ -119,7 +119,7 @@ namespace Api.Modules.Modules.Services
             var lastTableUpdates = await databaseHelpersService.GetLastTableUpdatesAsync();
             
             // Make sure that all triggers for Wiser tables are up-to-date.
-            if (!lastTableUpdates.ContainsKey(TriggersName) || lastTableUpdates[TriggersName] < new DateTime(2022, 10, 28))
+            if (!lastTableUpdates.ContainsKey(TriggersName) || lastTableUpdates[TriggersName] < new DateTime(2023, 1, 3))
             {
                 var createTriggersQuery = await ResourceHelpers.ReadTextResourceFromAssemblyAsync("Api.Core.Queries.WiserInstallation.CreateTriggers.sql");
                 await clientDatabaseConnection.ExecuteAsync(createTriggersQuery);
@@ -128,49 +128,49 @@ namespace Api.Modules.Modules.Services
                 clientDatabaseConnection.AddParameter("tableName", TriggersName);
                 clientDatabaseConnection.AddParameter("lastUpdate", DateTime.Now);
                 await clientDatabaseConnection.ExecuteAsync($@"INSERT INTO {WiserTableNames.WiserTableChanges} (name, last_update) 
-                                                            VALUES (?tableName, ?lastUpdate) 
-                                                            ON DUPLICATE KEY UPDATE last_update = VALUES(last_update)");
+VALUES (?tableName, ?lastUpdate) 
+ON DUPLICATE KEY UPDATE last_update = VALUES(last_update)");
             }
 
             clientDatabaseConnection.ClearParameters();
             clientDatabaseConnection.AddParameter("userId", IdentityHelpers.GetWiserUserId(identity));
 
             var query = $@"(
-                            SELECT
-	                            permission.module_id,
-	                            MAX(permission.permissions) AS permissions,
-                                module.name,
-                                module.icon,
-                                module.type,
-                                module.group,
-                                module.options,
-                                module.custom_query
-                            FROM {WiserTableNames.WiserUserRoles} AS user_role
-                            JOIN {WiserTableNames.WiserRoles} AS role ON role.id = user_role.role_id
-                            JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = role.id AND permission.module_id > 0
-                            JOIN {WiserTableNames.WiserModule} AS module ON module.id = permission.module_id
-                            WHERE user_role.user_id = ?userId
-                            GROUP BY permission.module_id
-                            ORDER BY permission.module_id, permission.permissions
-                        )";
+    SELECT
+	    permission.module_id,
+	    MAX(permission.permissions) AS permissions,
+        module.name,
+        module.icon,
+        module.type,
+        module.group,
+        module.options,
+        module.custom_query
+    FROM {WiserTableNames.WiserUserRoles} AS user_role
+    JOIN {WiserTableNames.WiserRoles} AS role ON role.id = user_role.role_id
+    JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = role.id AND permission.module_id > 0
+    JOIN {WiserTableNames.WiserModule} AS module ON module.id = permission.module_id
+    WHERE user_role.user_id = ?userId
+    GROUP BY permission.module_id
+    ORDER BY permission.module_id, permission.permissions
+)";
 
             if (isAdminAccount)
             {
                 query += $@"
-                        UNION
-                        (
-                            SELECT
-                                module.id AS module_id,
-                                15 AS permissions,
-                                module.name,
-                                module.icon,
-                                module.type,
-                                module.group,
-                                module.options,
-                                module.custom_query
-                            FROM {WiserTableNames.WiserModule} AS module
-                            WHERE module.id IN ({String.Join(",", modulesForAdmins)})
-                        )";
+UNION
+(
+    SELECT
+        module.id AS module_id,
+        15 AS permissions,
+        module.name,
+        module.icon,
+        module.type,
+        module.group,
+        module.options,
+        module.custom_query
+    FROM {WiserTableNames.WiserModule} AS module
+    WHERE module.id IN ({String.Join(",", modulesForAdmins)})
+)";
             }
 
             var dataTable = await clientDatabaseConnection.GetAsync(query);

--- a/Api/Modules/Templates/Services/HistoryService.cs
+++ b/Api/Modules/Templates/Services/HistoryService.cs
@@ -78,7 +78,7 @@ namespace Api.Modules.Templates.Services
             }
             
             var componentAndMode = await dataService.GetComponentAndModeFromContentIdAsync(contentId);
-            await dataService.SaveSettingsStringAsync(contentId, componentAndMode[0], componentAndMode[1], currentVersion.Key, currentVersion.Value, IdentityHelpers.GetUserName(identity));
+            await dataService.SaveSettingsStringAsync(contentId, componentAndMode[0], componentAndMode[1], currentVersion.Key, currentVersion.Value, IdentityHelpers.GetUserName(identity, true));
             return new ServiceResult<int>
             {
                 StatusCode = HttpStatusCode.NoContent

--- a/FrontEnd/Modules/Admin/Scripts/Admin.js
+++ b/FrontEnd/Modules/Admin/Scripts/Admin.js
@@ -157,7 +157,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? `Happy Horizon (${user.adminAccountName})` : user.name;
+            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
             this.settings.happyEmployeeLoggedIn = user.juiceEmployeeName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/Admin/Scripts/Admin.js
+++ b/FrontEnd/Modules/Admin/Scripts/Admin.js
@@ -157,8 +157,8 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
-            this.settings.happyEmployeeLoggedIn = user.juiceEmployeeName;
+            this.settings.username = user.adminAccountName ? `${user.adminAccountName} (Admin)` : user.name;
+            this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);
             this.settings.userId = userData.encryptedId;

--- a/FrontEnd/Modules/Communication/Scripts/Index.js
+++ b/FrontEnd/Modules/Communication/Scripts/Index.js
@@ -83,7 +83,7 @@ const communicationModuleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
+            this.settings.username = user.adminAccountName ? `${user.adminAccountName} (Admin)` : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/Communication/Scripts/Index.js
+++ b/FrontEnd/Modules/Communication/Scripts/Index.js
@@ -83,7 +83,7 @@ const communicationModuleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? `Happy Horizon (${user.adminAccountName})` : user.name;
+            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/Communication/Scripts/Settings.js
+++ b/FrontEnd/Modules/Communication/Scripts/Settings.js
@@ -122,7 +122,7 @@ const communicationModuleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? `Happy Horizon (${user.adminAccountName})` : user.name;
+            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/Communication/Scripts/Settings.js
+++ b/FrontEnd/Modules/Communication/Scripts/Settings.js
@@ -122,7 +122,7 @@ const communicationModuleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
+            this.settings.username = user.adminAccountName ? `${user.adminAccountName} (Admin)` : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/Dashboard/Scripts/Dashboard.js
+++ b/FrontEnd/Modules/Dashboard/Scripts/Dashboard.js
@@ -113,7 +113,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
+            this.settings.username = user.adminAccountName ? `${user.adminAccountName} (Admin)` : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/Dashboard/Scripts/Dashboard.js
+++ b/FrontEnd/Modules/Dashboard/Scripts/Dashboard.js
@@ -109,7 +109,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? `Happy Horizon (${user.adminAccountName})` : user.name;
+            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/DataSelector/Scripts/DataSelector.js
+++ b/FrontEnd/Modules/DataSelector/Scripts/DataSelector.js
@@ -90,7 +90,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? `Happy Horizon (${user.adminAccountName})` : user.name;
+            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/DataSelector/Scripts/DataSelector.js
+++ b/FrontEnd/Modules/DataSelector/Scripts/DataSelector.js
@@ -91,7 +91,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
+            this.settings.username = user.adminAccountName ? `${user.adminAccountName} (Admin)` : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
@@ -172,7 +172,7 @@ const moduleSettings = {
             // Get user data from local storage.
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? `Admin (${user.adminAccountName})` : user.name;
+            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             if (!this.settings.wiserApiRoot.endsWith("/")) {

--- a/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
@@ -172,7 +172,7 @@ const moduleSettings = {
             // Get user data from local storage.
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
+            this.settings.username = user.adminAccountName ? `${user.adminAccountName} (Admin)` : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             if (!this.settings.wiserApiRoot.endsWith("/")) {

--- a/FrontEnd/Modules/ImportExport/Scripts/Export.js
+++ b/FrontEnd/Modules/ImportExport/Scripts/Export.js
@@ -92,7 +92,7 @@ const exportModuleSettings = {
             
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
+            this.settings.username = user.adminAccountName ? `${user.adminAccountName} (Admin)` : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
             
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/ImportExport/Scripts/Export.js
+++ b/FrontEnd/Modules/ImportExport/Scripts/Export.js
@@ -92,7 +92,7 @@ const exportModuleSettings = {
             
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? `Happy Horizon (${user.adminAccountName})` : user.name;
+            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
             
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/ImportExport/Scripts/Import.js
+++ b/FrontEnd/Modules/ImportExport/Scripts/Import.js
@@ -105,7 +105,7 @@ const importModuleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? `Happy Horizon (${user.adminAccountName})` : user.name;
+            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
             this.settings.adminAccountLoggedIn = user.adminAccountName;
             
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/ImportExport/Scripts/Import.js
+++ b/FrontEnd/Modules/ImportExport/Scripts/Import.js
@@ -105,7 +105,7 @@ const importModuleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
+            this.settings.username = user.adminAccountName ? `${user.adminAccountName} (Admin)` : user.name;
             this.settings.adminAccountLoggedIn = user.adminAccountName;
             
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/TaskAlerts/Scripts/TaskAlerts.js
+++ b/FrontEnd/Modules/TaskAlerts/Scripts/TaskAlerts.js
@@ -91,7 +91,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
+            this.settings.username = user.adminAccountName ? `${user.adminAccountName} (Admin)` : user.name;
             this.settings.adminAccountLoggedIn = user.adminAccountName;
             
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/TaskAlerts/Scripts/TaskAlerts.js
+++ b/FrontEnd/Modules/TaskAlerts/Scripts/TaskAlerts.js
@@ -91,7 +91,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? `Happy Horizon (${user.adminAccountName})` : user.name;
+            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
             this.settings.adminAccountLoggedIn = user.adminAccountName;
             
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/TaskAlerts/Scripts/TaskHistory.js
+++ b/FrontEnd/Modules/TaskAlerts/Scripts/TaskHistory.js
@@ -62,7 +62,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
+            this.settings.username = user.adminAccountName ? `${user.adminAccountName} (Admin)` : user.name;
             this.settings.adminAccountLoggedIn = user.adminAccountName;
             
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/TaskAlerts/Scripts/TaskHistory.js
+++ b/FrontEnd/Modules/TaskAlerts/Scripts/TaskHistory.js
@@ -62,7 +62,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? `Happy Horizon (${user.adminAccountName})` : user.name;
+            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
             this.settings.adminAccountLoggedIn = user.adminAccountName;
             
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
+++ b/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
@@ -103,7 +103,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
+            this.settings.username = user.adminAccountName ? `${user.adminAccountName} (Admin)` : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
+++ b/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
@@ -103,7 +103,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? `Happy Horizon (${user.adminAccountName})` : user.name;
+            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/Templates/Scripts/Templates.js
+++ b/FrontEnd/Modules/Templates/Scripts/Templates.js
@@ -141,7 +141,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? `Happy Horizon (${user.adminAccountName})` : user.name;
+            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/Templates/Scripts/Templates.js
+++ b/FrontEnd/Modules/Templates/Scripts/Templates.js
@@ -141,7 +141,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
+            this.settings.username = user.adminAccountName ? `${user.adminAccountName} (Admin)` : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/VersionControl/Scripts/VersionControl.js
+++ b/FrontEnd/Modules/VersionControl/Scripts/VersionControl.js
@@ -92,7 +92,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
+            this.settings.username = user.adminAccountName ? `${user.adminAccountName} (Admin)` : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);

--- a/FrontEnd/Modules/VersionControl/Scripts/VersionControl.js
+++ b/FrontEnd/Modules/VersionControl/Scripts/VersionControl.js
@@ -92,7 +92,7 @@ const moduleSettings = {
 
             const user = JSON.parse(localStorage.getItem("userData"));
             this.settings.oldStyleUserId = user.oldStyleUserId;
-            this.settings.username = user.adminAccountName ? `Happy Horizon (${user.adminAccountName})` : user.name;
+            this.settings.username = user.adminAccountName ? user.adminAccountName : user.name;
             this.settings.adminAccountLoggedIn = !!user.adminAccountName;
 
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);


### PR DESCRIPTION
When the admin user makes changes in Wiser, it would always show the username in history of the user they selected during login. This is changes so that it will now always show their admin username in history.

Also changed username in scripts where it would use "Happy Horizon ([username])", but Happy Horizon is not applicable for external users that use Wiser.

Finally, I also fixed some problems that changes made to files would show the MySQL user in the history, instead of the Wiser user.

Asana ticket: https://app.asana.com/0/1201027711166952/1203205263979130