### PR TITLE
Add is_partial to initial creation of tables and move location in Wiser.

### DIFF
--- a/Api/Core/Queries/WiserInstallation/CreateTables.sql
+++ b/Api/Core/Queries/WiserInstallation/CreateTables.sql
@@ -705,6 +705,7 @@ CREATE TABLE IF NOT EXISTS `wiser_template`  (
    `is_default_header` tinyint(1) NOT NULL DEFAULT 0,
    `is_default_footer` tinyint(1) NOT NULL DEFAULT 0,
    `default_header_footer_regex` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
+   `is_partial` tinyint(1) NOT NULL DEFAULT 0,
    PRIMARY KEY (`id`) USING BTREE,
    UNIQUE INDEX `idx_unique`(`template_id` ASC, `version` ASC) USING BTREE,
    INDEX `idx_removed`(`removed` ASC) USING BTREE,

--- a/FrontEnd/Modules/Templates/Views/Templates/Partials/HtmlSettings.cshtml
+++ b/FrontEnd/Modules/Templates/Views/Templates/Partials/HtmlSettings.cshtml
@@ -83,11 +83,6 @@
             <div class="form-hint"><span>Indien hier een geldige regex is ingevuld, wordt deze header of footer alleen gebruikt voor URL's die voldoen aan deze regex.</span></div>
         </div>
     </div>
-
-    <input id="loginRequired" name="loginRequired" type="checkbox" @(Model.LoginRequired ? "checked" : "") class="hidden">
-    <label class="checkbox" for="loginRequired">
-        <span>Gebruiker moet ingelogd zijn om deze template te zien</span>
-    </label>
     
     <input id="isPartial" name="isPartial" type="checkbox" @(Model.IsPartial ? "checked" : "") class="hidden" />
     <label class="checkbox" for="isPartial">
@@ -98,6 +93,11 @@
             Wanneer aangevinkt wordt de ombouw nooit om de template gedaan wanneer deze wordt opgevraagd via een XHR call.
         </span>
     </div>
+
+    <input id="loginRequired" name="loginRequired" type="checkbox" @(Model.LoginRequired ? "checked" : "") class="hidden">
+    <label class="checkbox" for="loginRequired">
+        <span>Gebruiker moet ingelogd zijn om deze template te zien</span>
+    </label>
 
     <div class="user-check-panel">
         <div class="item" data-label-style="float" data-label-width="0">


### PR DESCRIPTION
"is_partial" column will now be added to the table during creation of a new customer.
https://app.asana.com/0/1201027711166952/1203654426049449/

The option in the settings is moved to a more logical location. (Git says "loginRequired" has changed because the "isPartial" is moved from under to above "loginRequired".)
https://app.asana.com/0/1201027711166952/1203601461297517/