### PR TITLE
Fixed grid incell editing

### DIFF
--- a/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
+++ b/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
@@ -404,7 +404,7 @@ async function generateGrid(data, model, columns) {
                             entityType: "{entityType}"
                         };
 
-                        var encryptedId = transportOptions.data.encryptedId || transportOptions.data.encrypted_id;
+                        var encryptedId = transportOptions.data.encryptedId || transportOptions.data.encrypted_id || transportOptions.data.encryptedid;
                         if (options.fieldGroupName) {
                             encryptedId = "{itemIdEncrypted}";
                             transportOptions.data.groupName = options.fieldGroupName;


### PR DESCRIPTION
A grid with incell editing enabled can now properly save values again. It didn't work previously because it couldn't determine an item's encrypted ID.

Asana: https://app.asana.com/0/1201763244049195/1203837014778910