### PR TITLE
Changes for linked-item properties

### DIFF
--- a/Api/Modules/Items/Controllers/ItemsController.cs
+++ b/Api/Modules/Items/Controllers/ItemsController.cs
@@ -94,6 +94,24 @@ namespace Api.Modules.Items.Controllers
         }
 
         /// <summary>
+        /// Retrieve an item that the given item is linked to, or and item that is linked to the given item.
+        /// </summary>
+        /// <param name="encryptedId">The encrypted ID of the main item.</param>
+        /// <param name="entityType">Optional: The entity type of the item to retrieve. This is needed when the item is saved in a different table than wiser_item. We can only look up the name of that table if we know the entity type beforehand.</param>
+        /// <param name="itemIdEntityType">Optional: You can enter the entity type of the given itemId here, if you want to get items from a dedicated table and those items can have multiple different entity types. This only works if all those items exist in the same table. Default is null.</param>
+        /// <param name="linkType">Optional: The type number of the link.</param>
+        /// <param name="reversed">Optional: Whether to retrieve an item that that given item is linked to (<see langword="true"/>), or an item that is linked to the given item (<see langword="false"/>).</param>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("{encryptedId}/linked/details")]
+        [ProducesResponseType(typeof(IEnumerable<WiserItemModel>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetLinkedItemDetailsAsync(string encryptedId, [FromQuery]string entityType = null, [FromQuery]string itemIdEntityType = null, [FromQuery]int linkType = 0, [FromQuery]bool reversed = false)
+        {
+            return (await itemsService.GetLinkedItemDetailsAsync(encryptedId, (ClaimsIdentity)User.Identity, entityType, itemIdEntityType, linkType, reversed)).GetHttpResponseMessage();
+        }
+
+        /// <summary>
         /// Get the meta data of an item. This is data such as the title, entity type, last change date etc.
         /// </summary>
         /// <param name="encryptedId">The encrypted ID of the item.</param>

--- a/Api/Modules/Items/Interfaces/IItemsService.cs
+++ b/Api/Modules/Items/Interfaces/IItemsService.cs
@@ -131,6 +131,18 @@ namespace Api.Modules.Items.Interfaces
         Task<ServiceResult<WiserItemModel>> GetItemDetailsAsync(string encryptedId, ClaimsIdentity identity, string entityType = null);
 
         /// <summary>
+        /// Returns all items linked to a given item, or all items the given item is linked to.
+        /// </summary>
+        /// <param name="encryptedId">The encrypted ID of the item to get.</param>
+        /// <param name="identity">The identity of the authenticated user.</param>
+        /// <param name="entityType">Optional: The entity type of the item to retrieve. This is needed when the item is saved in a different table than wiser_item. We can only look up the name of that table if we know the entity type beforehand.</param>
+        /// <param name="itemIdEntityType">Optional: You can enter the entity type of the given itemId here, if you want to get items from a dedicated table and those items can have multiple different entity types. This only works if all those items exist in the same table. Default is null.</param>
+        /// <param name="linkType">Optional: The type number of the link.</param>
+        /// <param name="reversed">Optional: Whether to retrieve an item that is linked to this item (<see langword="true"/>), or an item that this item is linked to (<see langword="false"/>).</param>
+        /// <returns></returns>
+        Task<ServiceResult<List<WiserItemModel>>> GetLinkedItemDetailsAsync(string encryptedId, ClaimsIdentity identity, string entityType = null, string itemIdEntityType = null, int linkType = 0, bool reversed = false);
+
+        /// <summary>
         /// Get the meta data of an item. This is data such as the title, entity type, last change date etc.
         /// </summary>
         /// <param name="encryptedId">The encrypted ID of the item.</param>

--- a/Api/Modules/Templates/Services/TemplatesService.cs
+++ b/Api/Modules/Templates/Services/TemplatesService.cs
@@ -295,8 +295,6 @@ ORDER BY template.ordering ASC");
                     {
                         "SEARCH_ITEMS_OLD",
                         "GET_ITEM_DETAILS",
-                        "GET_DESTINATION_ITEMS",
-                        "GET_DESTINATION_ITEMS_REVERSED",
                         "GET_DATA_FOR_TABLE",
                         "GET_DATA_FOR_FIELD_TABLE"
                     }.Contains(templateName))
@@ -1500,76 +1498,6 @@ AND (
 
 GROUP BY i.id
 ORDER BY ilp.ordering, i.title");
-                TemplateQueryStrings.Add("GET_DESTINATION_ITEMS", @"SET @_itemId = {itemId};
-SET @_entityType = IF('{entityType}' LIKE '{%}', 'item', '{entityType}');
-SET @_linkType = IF('{linkTypeNumber}' LIKE '{%}', '1', '{linkTypeNumber}');
-SET @userId = {encryptedUserId:decrypt(true)};
-
-SELECT 
-	i.id, 
-	i.id AS encryptedId_encrypt_withdate,
-    CASE i.published_environment
-    	WHEN 0 THEN 'onzichtbaar'
-        WHEN 1 THEN 'dev'
-        WHEN 2 THEN 'test'
-        WHEN 3 THEN 'acceptatie'
-        WHEN 4 THEN 'live'
-    END AS published_environment,
-	i.title, 
-	i.entity_type, 
-	id.`key` AS property_name,
-	CONCAT(IFNULL(id.`value`, ''), IFNULL(id.`long_value`, '')) AS property_value,
-	il.type AS link_type, 
-    il.id AS link_id
-FROM wiser_itemlink il
-JOIN wiser_item i ON i.id = il.destination_item_id AND i.entity_type = @_entityType
-
-# Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
-LEFT JOIN wiser_user_roles user_role ON user_role.user_id = @userId
-LEFT JOIN wiser_permission permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
-
-LEFT JOIN wiser_entityproperty p ON p.entity_name = i.entity_type
-LEFT JOIN wiser_itemdetail id ON id.item_id = il.destination_item_id AND ((p.property_name IS NOT NULL AND p.property_name <> '' AND id.`key` = p.property_name) OR ((p.property_name IS NULL OR p.property_name = '') AND id.`key` = p.display_name))
-WHERE il.item_id = @_itemId
-AND il.type = @_linkType
-AND (permission.id IS NULL OR (permission.permissions & 1) > 0)
-GROUP BY il.item_id, id.id
-ORDER BY il.ordering, i.title, i.id");
-                TemplateQueryStrings.Add("GET_DESTINATION_ITEMS_REVERSED", @"SET @_itemId = {itemId};
-SET @_entityType = IF('{entityType}' LIKE '{%}', 'item', '{entityType}');
-SET @_linkType = IF('{linkTypeNumber}' LIKE '{%}', '1', '{linkTypeNumber}');
-SET @userId = {encryptedUserId:decrypt(true)};
-
-SELECT 
-	i.id, 
-	i.id AS encryptedId_encrypt_withdate,
-    CASE i.published_environment
-    	WHEN 0 THEN 'onzichtbaar'
-        WHEN 1 THEN 'dev'
-        WHEN 2 THEN 'test'
-        WHEN 3 THEN 'acceptatie'
-        WHEN 4 THEN 'live'
-    END AS published_environment,
-	i.title, 
-	i.entity_type, 
-	id.`key` AS property_name,
-	CONCAT(IFNULL(id.`value`, ''), IFNULL(id.`long_value`, '')) AS property_value,
-	il.type AS link_type,
-    il.id AS link_id
-FROM wiser_itemlink il
-JOIN wiser_item i ON i.id = il.item_id AND i.entity_type = @_entityType
-
-# Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
-LEFT JOIN wiser_user_roles user_role ON user_role.user_id = @userId
-LEFT JOIN wiser_permission permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
-
-LEFT JOIN wiser_entityproperty p ON p.entity_name = i.entity_type
-LEFT JOIN wiser_itemdetail id ON id.item_id = il.item_id AND ((p.property_name IS NOT NULL AND p.property_name <> '' AND id.`key` = p.property_name) OR ((p.property_name IS NULL OR p.property_name = '') AND id.`key` = p.display_name))
-WHERE il.destination_item_id = @_itemId
-AND il.type = @_linkType
-AND (permission.id IS NULL OR (permission.permissions & 1) > 0)
-GROUP BY il.destination_item_id, id.id
-ORDER BY il.ordering, i.title, i.id");
                 TemplateQueryStrings.Add("GET_COLUMNS_FOR_TABLE", @"SET @selected_id = {itemId:decrypt(true)}; # 3077
 
 SELECT 


### PR DESCRIPTION
Made some changes to the linked-item properties:
* Now uses the newly made linked details endpoint in the items controller.
* The new linked details endpoint retrieves all details instead of only those defined in the entity properties.
* Added new option to remove unknown variables (`removeUnknownVariables`).
* Updated the scripts a bit to use modern functions.
* Removed the "GET_DESTINATION_ITEMS" and "GET_DESTINATION_ITEMS_REVERSED" queries from the templates service.

Asana: https://app.asana.com/0/1201027711166952/1203351288497689