### PR TITLE
Updated MySQL installation queries

### DIFF
--- a/Api/Core/Queries/WiserInstallation/CreateTables.sql
+++ b/Api/Core/Queries/WiserInstallation/CreateTables.sql
@@ -211,11 +211,17 @@ CREATE TABLE IF NOT EXISTS `wiser_itemdetail`  (
   `groupname` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '' COMMENT 'optionele groepering van items, zoals een \'specs\' tabel',
   `key` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
   `value` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `value_as_int` bigint GENERATED ALWAYS AS (CAST(`value` AS SIGNED)) VIRTUAL NULL,
+  `value_as_decimal` decimal(65,30) GENERATED ALWAYS AS (CAST(`value` AS DECIMAL(65,30))) VIRTUAL NULL,
   `long_value` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL COMMENT 'Voor waardes die niet in \'value\' passen, zoals van HTMLeditors',
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE INDEX `item_key`(`item_id`, `key`, `language_code`) USING BTREE COMMENT 'voor opbouwen productoverzicht',
   INDEX `key_value`(`key`(50), `value`(100)) USING BTREE COMMENT 'filteren van items',
+  INDEX `key_int_value`(`key`(50), `value_as_int`) USING BTREE,
+  INDEX `key_decimal_value`(`key`(50), `value_as_decimal`) USING BTREE,
   INDEX `item_id_key_value`(`item_id`, `key`(40), `value`(40)) USING BTREE,
+  INDEX `item_id_key_int_value`(`item_id`, `key`(40), `value_as_int`) USING BTREE,
+  INDEX `item_id_key_decimal_value`(`item_id`, `key`(40), `value_as_decimal`) USING BTREE,
   INDEX `item_id_group`(`item_id`, `groupname`, `key`(40)) USING BTREE
 ) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = Dynamic;
 
@@ -229,11 +235,17 @@ CREATE TABLE IF NOT EXISTS `wiser_itemdetail_archive`  (
   `groupname` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '' COMMENT 'optionele groepering van items, zoals een \'specs\' tabel',
   `key` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
   `value` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `value_as_int` bigint GENERATED ALWAYS AS (CAST(`value` AS SIGNED)) VIRTUAL NULL,
+  `value_as_decimal` decimal(65,30) GENERATED ALWAYS AS (CAST(`value` AS DECIMAL(65,30))) VIRTUAL NULL,
   `long_value` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL COMMENT 'Voor waardes die niet in \'value\' passen, zoals van HTMLeditors',
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE INDEX `item_key`(`item_id`, `key`, `language_code`) USING BTREE COMMENT 'voor opbouwen productoverzicht',
   INDEX `key_value`(`key`(50), `value`(100)) USING BTREE COMMENT 'filteren van items',
+  INDEX `key_int_value`(`key`(50), `value_as_int`) USING BTREE,
+  INDEX `key_decimal_value`(`key`(50), `value_as_decimal`) USING BTREE,
   INDEX `item_id_key_value`(`item_id`, `key`(40), `value`(40)) USING BTREE,
+  INDEX `item_id_key_int_value`(`item_id`, `key`(40), `value_as_int`) USING BTREE,
+  INDEX `item_id_key_decimal_value`(`item_id`, `key`(40), `value_as_decimal`) USING BTREE,
   INDEX `item_id_group`(`item_id`, `groupname`, `key`(40)) USING BTREE
 ) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = Dynamic;
 
@@ -337,11 +349,15 @@ CREATE TABLE IF NOT EXISTS `wiser_itemlinkdetail`  (
   `groupname` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '' COMMENT 'optionele groepering van items, zoals een \'specs\' tabel',
   `key` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
   `value` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `value_as_int` bigint GENERATED ALWAYS AS (CAST(`value` AS SIGNED)) VIRTUAL NULL,
+  `value_as_decimal` decimal(65,30) GENERATED ALWAYS AS (CAST(`value` AS DECIMAL(65,30))) VIRTUAL NULL,
   `long_value` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL COMMENT 'Voor waardes die niet in \'value\' passen, zoals van HTMLeditors',
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE INDEX `itemlink_key`(`itemlink_id`, `key`, `language_code`) USING BTREE COMMENT 'voor opbouwen productoverzicht',
   INDEX `itemlink_id`(`itemlink_id`) USING BTREE COMMENT 'voor zoeken waardes van 1 item',
-  INDEX `language_id`(`key`(50), `value`(100)) USING BTREE COMMENT 'filteren van items'
+  INDEX `key_value`(`key`(50), `value`(100)) USING BTREE COMMENT 'filteren van items',
+  INDEX `key_int_value`(`key`(50), `value_as_int`) USING BTREE,
+  INDEX `key_decimal_value`(`key`(50), `value_as_decimal`) USING BTREE
 ) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = Dynamic;
 
 -- ----------------------------
@@ -354,11 +370,15 @@ CREATE TABLE IF NOT EXISTS `wiser_itemlinkdetail_archive`  (
   `groupname` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '' COMMENT 'optionele groepering van items, zoals een \'specs\' tabel',
   `key` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
   `value` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `value_as_int` bigint GENERATED ALWAYS AS (CAST(`value` AS SIGNED)) VIRTUAL NULL,
+  `value_as_decimal` decimal(65,30) GENERATED ALWAYS AS (CAST(`value` AS DECIMAL(65,30))) VIRTUAL NULL,
   `long_value` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL COMMENT 'Voor waardes die niet in \'value\' passen, zoals van HTMLeditors',
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE INDEX `itemlink_key`(`itemlink_id`, `key`, `language_code`) USING BTREE COMMENT 'voor opbouwen productoverzicht',
   INDEX `itemlink_id`(`itemlink_id`) USING BTREE COMMENT 'voor zoeken waardes van 1 item',
-  INDEX `language_id`(`key`(50), `value`(100)) USING BTREE COMMENT 'filteren van items'
+  INDEX `key_value`(`key`(50), `value`(100)) USING BTREE COMMENT 'filteren van items',
+  INDEX `key_int_value`(`key`(50), `value_as_int`) USING BTREE,
+  INDEX `key_decimal_value`(`key`(50), `value_as_decimal`) USING BTREE
 ) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = Dynamic;
 
 -- ----------------------------

--- a/Api/Core/Queries/WiserInstallation/CreateTablesConfigurator.sql
+++ b/Api/Core/Queries/WiserInstallation/CreateTablesConfigurator.sql
@@ -62,11 +62,17 @@ CREATE TABLE IF NOT EXISTS `configurations_wiser_itemdetail`  (
   `groupname` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '' COMMENT 'optionele groepering van items, zoals een \'specs\' tabel',
   `key` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
   `value` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `value_as_int` bigint GENERATED ALWAYS AS (CAST(`value` AS SIGNED)) VIRTUAL NULL,
+  `value_as_decimal` decimal(65,30) GENERATED ALWAYS AS (CAST(`value` AS DECIMAL(65,30))) VIRTUAL NULL,
   `long_value` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL COMMENT 'Voor waardes die niet in \'value\' passen, zoals van HTMLeditors',
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE INDEX `item_key`(`item_id`, `key`, `language_code`) USING BTREE COMMENT 'voor opbouwen productoverzicht',
   INDEX `key_value`(`key`(50), `value`(100)) USING BTREE COMMENT 'filteren van items',
+  INDEX `key_int_value`(`key`(50), `value_as_int`) USING BTREE,
+  INDEX `key_decimal_value`(`key`(50), `value_as_decimal`) USING BTREE,
   INDEX `item_id_key_value`(`item_id`, `key`(40), `value`(40)) USING BTREE,
+  INDEX `item_id_key_int_value`(`item_id`, `key`(40), `value_as_int`) USING BTREE,
+  INDEX `item_id_key_decimal_value`(`item_id`, `key`(40), `value_as_decimal`) USING BTREE,
   INDEX `item_id_group`(`item_id`, `groupname`, `key`(40)) USING BTREE
 ) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = Dynamic;
 
@@ -80,11 +86,17 @@ CREATE TABLE IF NOT EXISTS `configurations_wiser_itemdetail_archive`  (
   `groupname` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '' COMMENT 'optionele groepering van items, zoals een \'specs\' tabel',
   `key` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
   `value` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `value_as_int` bigint GENERATED ALWAYS AS (CAST(`value` AS SIGNED)) VIRTUAL NULL,
+  `value_as_decimal` decimal(65,30) GENERATED ALWAYS AS (CAST(`value` AS DECIMAL(65,30))) VIRTUAL NULL,
   `long_value` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL COMMENT 'Voor waardes die niet in \'value\' passen, zoals van HTMLeditors',
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE INDEX `item_key`(`item_id`, `key`, `language_code`) USING BTREE COMMENT 'voor opbouwen productoverzicht',
   INDEX `key_value`(`key`(50), `value`(100)) USING BTREE COMMENT 'filteren van items',
+  INDEX `key_int_value`(`key`(50), `value_as_int`) USING BTREE,
+  INDEX `key_decimal_value`(`key`(50), `value_as_decimal`) USING BTREE,
   INDEX `item_id_key_value`(`item_id`, `key`(40), `value`(40)) USING BTREE,
+  INDEX `item_id_key_int_value`(`item_id`, `key`(40), `value_as_int`) USING BTREE,
+  INDEX `item_id_key_decimal_value`(`item_id`, `key`(40), `value_as_decimal`) USING BTREE,
   INDEX `item_id_group`(`item_id`, `groupname`, `key`(40)) USING BTREE
 ) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = Dynamic;
 
@@ -98,11 +110,15 @@ CREATE TABLE IF NOT EXISTS `configurations_wiser_itemlinkdetail`  (
   `groupname` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '' COMMENT 'optionele groepering van items, zoals een \'specs\' tabel',
   `key` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
   `value` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `value_as_int` bigint GENERATED ALWAYS AS (CAST(`value` AS SIGNED)) VIRTUAL NULL,
+  `value_as_decimal` decimal(65,30) GENERATED ALWAYS AS (CAST(`value` AS DECIMAL(65,30))) VIRTUAL NULL,
   `long_value` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL COMMENT 'Voor waardes die niet in \'value\' passen, zoals van HTMLeditors',
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE INDEX `itemlink_key`(`itemlink_id`, `key`, `language_code`) USING BTREE COMMENT 'voor opbouwen productoverzicht',
   INDEX `itemlink_id`(`itemlink_id`) USING BTREE COMMENT 'voor zoeken waardes van 1 item',
-  INDEX `language_id`(`key`(50), `value`(100)) USING BTREE COMMENT 'filteren van items'
+  INDEX `key_value`(`key`(50), `value`(100)) USING BTREE COMMENT 'filteren van items',
+  INDEX `key_int_value`(`key`(50), `value_as_int`) USING BTREE,
+  INDEX `key_decimal_value`(`key`(50), `value_as_decimal`) USING BTREE
 ) ENGINE = InnoDB AUTO_INCREMENT = 1 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = DYNAMIC;
 
 -- ----------------------------
@@ -115,11 +131,15 @@ CREATE TABLE IF NOT EXISTS `configurations_wiser_itemlinkdetail_archive`  (
   `groupname` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '' COMMENT 'optionele groepering van items, zoals een \'specs\' tabel',
   `key` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
   `value` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `value_as_int` bigint GENERATED ALWAYS AS (CAST(`value` AS SIGNED)) VIRTUAL NULL,
+  `value_as_decimal` decimal(65,30) GENERATED ALWAYS AS (CAST(`value` AS DECIMAL(65,30))) VIRTUAL NULL,
   `long_value` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL COMMENT 'Voor waardes die niet in \'value\' passen, zoals van HTMLeditors',
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE INDEX `itemlink_key`(`itemlink_id`, `key`, `language_code`) USING BTREE COMMENT 'voor opbouwen productoverzicht',
   INDEX `itemlink_id`(`itemlink_id`) USING BTREE COMMENT 'voor zoeken waardes van 1 item',
-  INDEX `language_id`(`key`(50), `value`(100)) USING BTREE COMMENT 'filteren van items'
+  INDEX `key_value`(`key`(50), `value`(100)) USING BTREE COMMENT 'filteren van items',
+  INDEX `key_int_value`(`key`(50), `value_as_int`) USING BTREE,
+  INDEX `key_decimal_value`(`key`(50), `value_as_decimal`) USING BTREE
 ) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = Dynamic;
 
 -- ----------------------------


### PR DESCRIPTION
The MySQL installations queries have been updated so they also create some additional columns in `wiser_itemdetail` and `wiser_itemlinkdetail`: `value_as_int` and `value_as_decimal`. These virtual columns will automatically convert the value column to an int and decimal value respectively.

Related GCL pull request: https://github.com/happy-geeks/geeks-core-library/pull/515

Asana:
https://app.asana.com/0/29553867016121/1203457154031219
https://app.asana.com/0/29553867016121/1202994198179349