### PR TITLE
Disambiguate fieldnames

### DIFF
--- a/Api/Modules/Templates/Services/TemplatesService.cs
+++ b/Api/Modules/Templates/Services/TemplatesService.cs
@@ -602,8 +602,9 @@ WHERE il1.id = @_linkId;
 UPDATE wiser_itemlink
 SET destination_item_id = @destinationId, ordering = @newOrderNumber
 WHERE id = @_linkId;");
-                TemplateQueryStrings.Add("GET_OPTIONS_FOR_DEPENDENCY", @"SELECT DISTINCT entity_name AS entityName, IF(tab_name = """", ""Gegevens"", tab_name) as tabName, display_name AS displayName, property_name AS propertyName FROM wiser_entityproperty
-WHERE entity_name = '{entityName}'");
+                TemplateQueryStrings.Add("GET_OPTIONS_FOR_DEPENDENCY", @"SELECT DISTINCT entity_name AS entityName, IF(tab_name = """", ""Gegevens"", tab_name) as tabName, CONCAT(IF(tab_name = """", ""Gegevens"", tab_name), "" --> "", display_name) AS displayName, property_name AS propertyName FROM wiser_entityproperty
+WHERE entity_name = '{entityName}'
+ORDER BY displayName");
 
                 TemplateQueryStrings.Add("GET_ALL_INPUT_TYPES", @"SELECT DISTINCT inputtype FROM wiser_entityproperty ORDER BY inputtype");
                 TemplateQueryStrings.Add("DELETE_ENTITYPROPERTY", @"DELETE FROM wiser_entityproperty WHERE tab_name = '{tabName}' AND entity_name = '{entityName}' AND id = '{entityPropertyId}'");


### PR DESCRIPTION
https://app.asana.com/0/0/1203089430259003/f

In de beheer scherm bij de dropdown voor veld afhankelijkheden zijn de velden duidelijker gemaakt door de tabnaam erbij te zetten. Dit is hetzelfde idee als al bij de Entiteiten is gedaan. De gebruikte format is dan ook hetzelfde. 
Bijvoorbeeld "Gegevens --> Product naam"

![image](https://user-images.githubusercontent.com/15679930/236483632-48833a91-c92d-4944-87fd-37554199da8b.png)
