### PR TITLE
Always parse value to string

### DIFF
--- a/FrontEnd/Modules/Admin/Scripts/EntityTab.js
+++ b/FrontEnd/Modules/Admin/Scripts/EntityTab.js
@@ -3722,7 +3722,7 @@ export class EntityTab {
 
                 // set linked item entity to option defined type
                 this.linkedItemEntity.select((dataItem) => {
-                    return dataItem.id === optionsEentityType;
+                    return dataItem.id === optionsEntityType;
                 });
                 // set the template
                 document.getElementById("linkedItemTemplate").value = getOptionValueAndDeleteForOptionsField("template");

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -1955,9 +1955,9 @@ export class Fields {
 
                         // The queryActionResult are from a previously executed query. This way you can combine the actions executeQuery(Once) and openWindow to open a newly created or updated item.
                         if (queryActionResult) {
-                            windowItemId = windowItemId.replace(/{itemId}/gi, queryActionResult.itemId || 0);
-                            windowLinkId = windowLinkId.replace(/{linkId}/gi, queryActionResult.linkId || 0);
-                            windowLinkType = windowLinkType.replace(/{linkType}/gi, queryActionResult.linkType || queryActionResult.linkTypeNumber || 0);
+                            windowItemId = windowItemId.toString().replace(/{itemId}/gi, queryActionResult.itemId || 0);
+                            windowLinkId = windowLinkId.toString().replace(/{linkId}/gi, queryActionResult.linkId || 0);
+                            windowLinkType = windowLinkType.toString().replace(/{linkType}/gi, queryActionResult.linkType || queryActionResult.linkTypeNumber || 0);
                         }
                         windowItemId = Wiser.doWiserItemReplacements(windowItemId, mainItemDetails);
 


### PR DESCRIPTION
When the value is set directly instead of by a replacement it can be an integer causing an exception to be thrown on the replace function.

By always parsing it to a string the replace function can be called. If the value was already a string it did already return as a string.

https://app.asana.com/0/1144661858028300/1204522191718286