### PR TITLE
Add TinyPNG support

### DIFF
--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -175,6 +175,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="Tinify" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Api/Modules/Files/Models/TinyPngSettings.cs
+++ b/Api/Modules/Files/Models/TinyPngSettings.cs
@@ -1,0 +1,12 @@
+namespace Api.Modules.Files.Models;
+
+/// <summary>
+/// Settings for the tinyPng client
+/// </summary>
+public class TinyPngSettings
+{
+    /// <summary>
+    /// Gets or sets the api key used for TinyPng
+    /// </summary>
+    public string TinifyApiKey { get; set; }
+}

--- a/Api/Modules/Files/Services/FilesService.cs
+++ b/Api/Modules/Files/Services/FilesService.cs
@@ -149,7 +149,6 @@ namespace Api.Modules.Files.Services
                         try
                         {
                             fileBytes = await Tinify.FromBuffer(fileBytes).ToBuffer();
-                            tinifyProblemEncountered = true;
                         }
                         catch (ClientException e)
                         {

--- a/Api/Modules/Files/Services/FilesService.cs
+++ b/Api/Modules/Files/Services/FilesService.cs
@@ -152,12 +152,12 @@ namespace Api.Modules.Files.Services
                         }
                         catch (ClientException e)
                         {
-                            logger.LogDebug(e,"Problem with input encountered when calling the tinyPng API");
+                            logger.LogDebug(e, "Problem with input encountered when calling the tinyPng API");
                             tinifyProblemEncountered = true;
                         }
                         catch (AccountException e)
                         {
-                            logger.LogError(e,"Account Problem encountered when calling the tinyPng API");
+                            logger.LogError(e, "Account Problem encountered when calling the tinyPng API");
 
                             // Don't try to tinify the rest of the images after an accountException
                             useTinyPng = false;
@@ -165,13 +165,13 @@ namespace Api.Modules.Files.Services
                         }
                         catch (ConnectionException e)
                         {
-                            logger.LogInformation(e,"Network problem encountered when calling the tinyPng API");
+                            logger.LogInformation(e, "Network problem encountered when calling the tinyPng API");
                             useTinyPng = false;
                             tinifyProblemEncountered = true;
                         }
                         catch (ServerException e)
                         {
-                            logger.LogInformation(e,"Third party server problem encountered when calling the tinyPng API");
+                            logger.LogInformation(e, "Third party server problem encountered when calling the tinyPng API");
                             useTinyPng = false;
                             tinifyProblemEncountered = true;
                         }

--- a/Api/Modules/Files/Services/FilesService.cs
+++ b/Api/Modules/Files/Services/FilesService.cs
@@ -25,8 +25,10 @@ using GeeksCoreLibrary.Core.Services;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MySql.Data.MySqlClient;
 using Newtonsoft.Json.Linq;
+using TinifyAPI;
 
 namespace Api.Modules.Files.Services
 {
@@ -43,7 +45,7 @@ namespace Api.Modules.Files.Services
         /// <summary>
         /// Creates a new instance of <see cref="FilesService"/>.
         /// </summary>
-        public FilesService(IWiserCustomersService wiserCustomersService, ILogger<FilesService> logger, IDatabaseConnection databaseConnection, IWiserItemsService wiserItemsService, ICloudFlareService cloudFlareService, IFilesRepository filesRepository)
+        public FilesService(IWiserCustomersService wiserCustomersService, ILogger<FilesService> logger, IDatabaseConnection databaseConnection, IWiserItemsService wiserItemsService, ICloudFlareService cloudFlareService, IFilesRepository filesRepository, IOptions<TinyPngSettings> tinyPngSettings)
         {
             this.wiserCustomersService = wiserCustomersService;
             this.logger = logger;
@@ -51,6 +53,8 @@ namespace Api.Modules.Files.Services
             this.wiserItemsService = wiserItemsService;
             this.cloudFlareService = cloudFlareService;
             this.filesRepository = filesRepository;
+            
+            Tinify.Key ??= tinyPngSettings.Value.TinifyApiKey;
         }
 
         /// <inheritdoc />
@@ -121,16 +125,12 @@ namespace Api.Modules.Files.Services
 
                 var (ftpDirectory, ftpSettings) = await GetFtpSettingsAsync(identity, itemLinkId, propertyName, itemId);
 
-                if (useTinyPng)
-                {
-                    throw new NotImplementedException("Tiny PNG not supported yet.");
-                }
-
                 // Fix ordering of files.
                 await FixOrderingAsync(itemId, itemLinkId, propertyName, identity);
 
                 var result = new List<FileModel>();
 
+                var tinifyProblemEncountered = false;
                 foreach (var file in files)
                 {
                     byte[] fileBytes;
@@ -143,10 +143,39 @@ namespace Api.Modules.Files.Services
                     var fileName = file.FileName?.Trim('"');
                     fileName = Path.GetFileNameWithoutExtension(fileName).ConvertToSeo() + Path.GetExtension(fileName)?.ToLowerInvariant();
                     var fileExtension = Path.GetExtension(fileName);
-
+                    
                     if (useTinyPng && (fileExtension.Equals(".png", StringComparison.OrdinalIgnoreCase) || fileExtension.Equals(".jpg", StringComparison.OrdinalIgnoreCase)))
                     {
-                        throw new NotImplementedException("Tiny PNG not supported yet.");
+                        try
+                        {
+                            fileBytes = await Tinify.FromBuffer(fileBytes).ToBuffer();
+                            tinifyProblemEncountered = true;
+                        }
+                        catch (ClientException e)
+                        {
+                            logger.LogDebug(e,"Problem with input encountered when calling the tinyPng API");
+                            tinifyProblemEncountered = true;
+                        }
+                        catch (AccountException e)
+                        {
+                            logger.LogError(e,"Account Problem encountered when calling the tinyPng API");
+
+                            // Don't try to tinify the rest of the images after an accountException
+                            useTinyPng = false;
+                            tinifyProblemEncountered = true;
+                        }
+                        catch (ConnectionException e)
+                        {
+                            logger.LogInformation(e,"Network problem encountered when calling the tinyPng API");
+                            useTinyPng = false;
+                            tinifyProblemEncountered = true;
+                        }
+                        catch (ServerException e)
+                        {
+                            logger.LogInformation(e,"Third party server problem encountered when calling the tinyPng API");
+                            useTinyPng = false;
+                            tinifyProblemEncountered = true;
+                        }
                     }
 
                     var fileResult = await SaveAsync(identity, fileBytes, file.ContentType, fileName, propertyName, title, ftpSettings, ftpDirectory, itemId, itemLinkId, useCloudFlare, entityType, linkType);
@@ -162,6 +191,15 @@ namespace Api.Modules.Files.Services
                     result.Add(fileResult.ModelObject);
                 }
 
+                if (tinifyProblemEncountered)
+                {
+                    return new ServiceResult<List<FileModel>>(result)
+                    {
+                        StatusCode = HttpStatusCode.OK,
+                        ErrorMessage = "Partial success: file uploaded but not all images tinified"
+                    };
+                }
+                    
                 return new ServiceResult<List<FileModel>>(result);
             }
             catch (MySqlException mySqlException)

--- a/Api/Startup.cs
+++ b/Api/Startup.cs
@@ -14,6 +14,7 @@ using Api.Core.Services;
 using Api.Modules.Customers.Interfaces;
 using Api.Modules.Customers.Services;
 using Api.Modules.DigitalOcean.Models;
+using Api.Modules.Files.Models;
 using Api.Modules.Google.Models;
 using Api.Modules.Languages.Interfaces;
 using Api.Modules.Languages.Services;
@@ -91,6 +92,7 @@ namespace Api
             services.Configure<ApiSettings>(Configuration.GetSection("Api"));
             services.Configure<DigitalOceanSettings>(Configuration.GetSection("DigitalOcean"));
             services.Configure<GoogleSettings>(Configuration.GetSection("Google"));
+            services.Configure<TinyPngSettings>(Configuration.GetSection("TinyPNG"));
 
             // Use Serilog as our main logger.
             services.AddLogging(builder => { builder.AddSerilog(); });


### PR DESCRIPTION
https://app.asana.com/0/1201027711166952/1204477365701444/f

Adds support for tinyPNG during upload.

Api key should be added by with `TinifyApiKey` in an `TinyPNG` section

App settings example:
`
  "TinyPNG": {
    "TinifyApiKey": "YOUR_KEY_HERE"
  }
`