### PR TITLE
Bugfix/example configurator

### DIFF
--- a/Api/Core/Queries/WiserInstallation/InsertInitialDataConfigurator.sql
+++ b/Api/Core/Queries/WiserInstallation/InsertInitialDataConfigurator.sql
@@ -225,7 +225,7 @@ INSERT INTO `wiser_itemdetail` (`item_id`, `key`, `value`) VALUES (@stepTwoOneId
 
 -- Templates
 -- Configurator dynamic content
-SET @newContentId = (SELECT MAX(`content_id`) + 1 FROM `wiser_dynamic_content`);
+SET @newContentId = (SELECT IFNULL(MAX(`content_id`), 0) + 1 FROM `wiser_dynamic_content`);
 INSERT INTO `wiser_dynamic_content` (`content_id`, `settings`, `component`, `component_mode`, `version`, `title`, `changed_on`, `changed_by`, `published_environment`) VALUES (@newContentId, '{"ConfiguratorName":"ExampleConfigurator","ValuesCanContainDashes":false,"ProductsApiBaseUrl":"","ProductsApiGetProductsUrl":"","ProductsApiSalesPriceProperty":"","ProductsApiPurchasePriceProperty":"","ProductsApiFromPriceProperty":"","UserNeedsToBeLoggedIn":false,"HandleRequest":false,"EvaluateIfElseInTemplates":true,"RemoveUnknownVariables":true,"CachingMode":"0","CachingLocation":"0","CacheMinutes":0,"ComponentMode":"1"}', 'Configurator', 'Default', 1, 'ExampleConfigurator', NOW(), 'Wiser', 1);
 SET @configuratorDynamicContentId = (SELECT `content_id` FROM `wiser_dynamic_content` WHERE `id` = LAST_INSERT_ID());
 

--- a/Api/Core/Queries/WiserInstallation/InsertInitialDataConfigurator.sql
+++ b/Api/Core/Queries/WiserInstallation/InsertInitialDataConfigurator.sql
@@ -231,12 +231,12 @@ SET @configuratorDynamicContentId = (SELECT `content_id` FROM `wiser_dynamic_con
 
 -- Configurator scripts folder
 SET @scriptsFolderTemplateId = (SELECT `template_id` FROM `wiser_template` WHERE `template_name` = 'SCRIPTS');
-SET @newTemplateId = (SELECT MAX(`template_id`) + 1 FROM `wiser_template`);
+SET @newTemplateId = (SELECT IFNULL(MAX(`template_id`), 0) + 1 FROM `wiser_template`);
 INSERT INTO `wiser_template` (`parent_id`, `template_name`, `template_type`, `version`, `template_id`, `changed_on`, `changed_by`, `published_environment`) VALUES (@scriptsFolderTemplateId, 'Configurators', 7, 1, @newTemplateId, NOW(), 'Wiser', 1);
 SET @configuratorScriptsFolder = (SELECT `template_id` FROM `wiser_template` WHERE `id` = LAST_INSERT_ID());
 
 -- Configurator script template
-SET @newTemplateId = (SELECT MAX(`template_id`) + 1 FROM `wiser_template`);
+SET @newTemplateId = (SELECT IFNULL(MAX(`template_id`), 0) + 1 FROM `wiser_template`);
 INSERT INTO `wiser_template` (`parent_id`, `template_name`, `template_data`, `template_type`, `version`, `template_id`, `changed_on`, `changed_by`, `published_environment`) VALUES (@configuratorScriptsFolder, 'ExampleConfigurator',
 CONCAT('class ExampleConfigurator {
     constructor() {
@@ -271,12 +271,12 @@ SET @configuratorScriptTemplateId = (SELECT `template_id` FROM `wiser_template` 
 
 -- Configurator HTML folder
 SET @htmlFolderTemplateId = (SELECT `template_id` FROM `wiser_template` WHERE `template_name` = 'HTML');
-SET @newTemplateId = (SELECT MAX(`template_id`) + 1 FROM `wiser_template`);
+SET @newTemplateId = (SELECT IFNULL(MAX(`template_id`), 0) + 1 FROM `wiser_template`);
 INSERT INTO `wiser_template` (`parent_id`, `template_name`, `template_type`, `version`, `template_id`, `changed_on`, `changed_by`, `published_environment`) VALUES (@htmlFolderTemplateId, 'Configurators', 7, 1, @newTemplateId, NOW(), 'Wiser', 1);
 SET @configuratorTemplateFolder = (SELECT `template_id` FROM `wiser_template` WHERE `id` = LAST_INSERT_ID());
 
 -- Configurator HTML template
-SET @newTemplateId = (SELECT MAX(`template_id`) + 1 FROM `wiser_template`);
+SET @newTemplateId = (SELECT IFNULL(MAX(`template_id`), 0) + 1 FROM `wiser_template`);
 INSERT INTO `wiser_template` (`parent_id`, `template_name`, `template_data`, `template_type`, `version`, `template_id`, `changed_on`, `changed_by`, `published_environment`, `linked_templates`) VALUES (@configuratorTemplateFolder, 'ExampleConfigurator', CONCAT('<div class="dynamic-content" content-id="', @configuratorDynamicContentId, '"><h2>ExampleConfigurator</h2></div>'), 1, 1, @newTemplateId, NOW(), 'Wiser', 1, @configuratorScriptTemplateId);
 SET @configuratorHtmlTemplateId = (SELECT `template_id` FROM `wiser_template` WHERE `id` = LAST_INSERT_ID());
 


### PR DESCRIPTION
When no dynamic content yet exists the content_id could not be determined causing problems. Same check applied to templates to be sure.