### PR TITLE
Changes how the templates module works with versions

### DIFF
--- a/Api/Modules/Templates/Controllers/DynamicContentController.cs
+++ b/Api/Modules/Templates/Controllers/DynamicContentController.cs
@@ -92,7 +92,7 @@ namespace Api.Modules.Templates.Controllers
         [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
         public async Task<IActionResult> SaveSettingsAsync(int id, DynamicContentOverviewModel data)
         {
-            return (await dynamicContentService.SaveNewSettingsAsync((ClaimsIdentity)User.Identity, id, data.Component, data.ComponentModeId ?? 0, data.Title, data.Data)).GetHttpResponseMessage();
+            return (await dynamicContentService.SaveAsync((ClaimsIdentity)User.Identity, id, data.Component, data.ComponentModeId ?? 0, data.Title, data.Data)).GetHttpResponseMessage();
         }
 
         /// <summary>

--- a/Api/Modules/Templates/Controllers/TemplatesController.cs
+++ b/Api/Modules/Templates/Controllers/TemplatesController.cs
@@ -17,12 +17,11 @@ using GeeksCoreLibrary.Core.Enums;
 using GeeksCoreLibrary.Core.Extensions;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Templates.Enums;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
-using ITemplatesService = Api.Modules.Templates.Interfaces.ITemplatesService;
 
 namespace Api.Modules.Templates.Controllers
 {
@@ -75,7 +74,7 @@ namespace Api.Modules.Templates.Controllers
 
             return (await templatesService.GetCssForHtmlEditorsAsync(dummyClaimsIdentity)).GetHttpResponseMessage("text/css");
         }
-        
+
         /// <summary>
         /// Gets a query from the wiser database and executes it in the customer database.
         /// </summary>
@@ -95,7 +94,7 @@ namespace Api.Modules.Templates.Controllers
 
             return (await templatesService.GetAndExecuteQueryAsync((ClaimsIdentity)User.Identity, templateName, requestPostData)).GetHttpResponseMessage();
         }
-        
+
         /// <summary>
         /// Retrieve the tree view section underlying the parentId. Transforms the tree view section into a list of TemplateTreeViewModels.
         /// </summary>
@@ -108,7 +107,7 @@ namespace Api.Modules.Templates.Controllers
         {
             return (await templatesService.GetTreeViewSectionAsync((ClaimsIdentity)User.Identity, parentId)).GetHttpResponseMessage();
         }
-        
+
         /// <summary>
         /// Retrieve the history of the template. This will include changes made to dynamic content between the releases of templates and the publishes to different environments from this template. This data is collected and combined in a TemnplateHistoryOverviewModel
         /// </summary>
@@ -121,7 +120,7 @@ namespace Api.Modules.Templates.Controllers
         {
             return (await templatesService.GetTemplateHistoryAsync((ClaimsIdentity)User.Identity, templateId)).GetHttpResponseMessage();
         }
-        
+
         /// <summary>
         /// Retrieve al the preview profiles for an item.
         /// </summary>
@@ -134,7 +133,7 @@ namespace Api.Modules.Templates.Controllers
         {
             return (await previewService.GetAsync(templateId)).GetHttpResponseMessage();
         }
-        
+
         /// <summary>
         /// Get the meta data (name, changedOn, changedBy etc) from a template.
         /// </summary>
@@ -149,7 +148,7 @@ namespace Api.Modules.Templates.Controllers
         }
 
         /// <summary>
-        /// Retrieve the latest version of the template. 
+        /// Retrieve the latest version of the template.
         /// </summary>
         /// <param name="templateId">The id of the template to retrieve.</param>
         /// <returns>A template model containing the data of the templateversion.</returns>
@@ -216,8 +215,8 @@ namespace Api.Modules.Templates.Controllers
         public async Task<IActionResult> PublishToEnvironmentAsync(int templateId, Environments environment, int version)
         {
             var currentPublished = await templatesService.GetTemplateEnvironmentsAsync(templateId);
-            return currentPublished.StatusCode != HttpStatusCode.OK 
-                ? currentPublished.GetHttpResponseMessage() 
+            return currentPublished.StatusCode != HttpStatusCode.OK
+                ? currentPublished.GetHttpResponseMessage()
                 : (await templatesService.PublishToEnvironmentAsync((ClaimsIdentity)User.Identity, templateId, version, environment, currentPublished.ModelObject)).GetHttpResponseMessage();
         }
 
@@ -247,9 +246,9 @@ namespace Api.Modules.Templates.Controllers
         public async Task<IActionResult> SaveAsync(int templateId, TemplateSettingsModel templateData, bool skipCompilation = false)
         {
             templateData.TemplateId = templateId;
-            return (await templatesService.SaveTemplateVersionAsync((ClaimsIdentity)User.Identity, templateData, skipCompilation)).GetHttpResponseMessage();
+            return (await templatesService.SaveAsync((ClaimsIdentity)User.Identity, templateData, skipCompilation)).GetHttpResponseMessage();
         }
-        
+
         /// <summary>
         /// Renames a template. This will create a new version of the template with the name, so that we can always see in the history that the name has been changed.
         /// </summary>
@@ -262,7 +261,7 @@ namespace Api.Modules.Templates.Controllers
         {
             return (await templatesService.RenameAsync((ClaimsIdentity)User.Identity, templateId, newName)).GetHttpResponseMessage();
         }
-        
+
         /// <summary>
         /// Deletes a template. This will not actually delete it from the database, but add a new version with removed = 1 instead.
         /// </summary>
@@ -275,7 +274,7 @@ namespace Api.Modules.Templates.Controllers
         {
             return (await templatesService.DeleteAsync((ClaimsIdentity)User.Identity, templateId, alsoDeleteChildren)).GetHttpResponseMessage();
         }
-        
+
         /// <summary>
         /// Search for a template.
         /// </summary>
@@ -287,7 +286,7 @@ namespace Api.Modules.Templates.Controllers
         {
             return (await templatesService.SearchAsync((ClaimsIdentity)User.Identity, searchValue)).GetHttpResponseMessage();
         }
-        
+
         /// <summary>
         /// Moves a template to a new position.
         /// </summary>
@@ -301,7 +300,7 @@ namespace Api.Modules.Templates.Controllers
         {
             return (await templatesService.MoveAsync((ClaimsIdentity)User.Identity, sourceId, destinationId, dropPosition)).GetHttpResponseMessage();
         }
-        
+
         /// <summary>
         /// Retrieve al the preview profiles for an item.
         /// </summary>
@@ -314,7 +313,7 @@ namespace Api.Modules.Templates.Controllers
         {
             return (await previewService.GetAsync(templateId)).GetHttpResponseMessage();
         }
-        
+
         /// <summary>
         /// Creates a new instance of a preview profile with the given data.
         /// </summary>
@@ -345,7 +344,7 @@ namespace Api.Modules.Templates.Controllers
         }
 
         /// <summary>
-        /// Delete a profile from the database. 
+        /// Delete a profile from the database.
         /// </summary>
         /// <param name="templateId">The id of the template bound to the profile. This is added a an extra security for the deletion.</param>
         /// <param name="profileId">The id of the profile that is to be deleted</param>
@@ -371,7 +370,7 @@ namespace Api.Modules.Templates.Controllers
         {
             return (await templatesService.GetEntireTreeViewStructureAsync((ClaimsIdentity)User.Identity, 0, startFrom, environment)).GetHttpResponseMessage();
         }
-        
+
         /// <summary>
         /// Generates a preview for a HTML template.
         /// </summary>
@@ -451,7 +450,7 @@ namespace Api.Modules.Templates.Controllers
         {
             return (await templatesService.DeployToBranchAsync((ClaimsIdentity) User.Identity, new List<int> { templateId }, branchId)).GetHttpResponseMessage();
         }
-        
+
         /// <summary>
         /// Get the settings for measurements of a template.
         /// </summary>
@@ -464,7 +463,7 @@ namespace Api.Modules.Templates.Controllers
         {
             return (await templatesService.GetMeasurementSettingsAsync(templateId)).GetHttpResponseMessage();
         }
-        
+
         /// <summary>
         /// Save the settings for measurements of this template.
         /// </summary>
@@ -477,7 +476,7 @@ namespace Api.Modules.Templates.Controllers
         {
             return (await templatesService.SaveMeasurementSettingsAsync(settings, templateId)).GetHttpResponseMessage();
         }
-        
+
         /// <summary>
         /// Get rendering logs from database, filtered by the parameters.
         /// </summary>
@@ -498,7 +497,7 @@ namespace Api.Modules.Templates.Controllers
         [ProducesResponseType(typeof(MeasurementSettings), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetRenderLogsAsync(int templateId, int version = 0,
             string urlRegex = null, Environments? environment = null, ulong userId = 0,
-            string languageCode = null, int pageSize = 500, int pageNumber = 1, 
+            string languageCode = null, int pageSize = 500, int pageNumber = 1,
             bool getDailyAverage = false, DateTime? start = null, DateTime? end = null)
         {
             return (await templatesService.GetRenderLogsAsync(templateId, version, urlRegex, environment, userId, languageCode, pageSize, pageNumber, getDailyAverage, start, end)).GetHttpResponseMessage();

--- a/Api/Modules/Templates/Interfaces/DataLayer/IDynamicContentDataService.cs
+++ b/Api/Modules/Templates/Interfaces/DataLayer/IDynamicContentDataService.cs
@@ -17,7 +17,7 @@ namespace Api.Modules.Templates.Interfaces.DataLayer
         /// <param name="templateId">The ID of the template.</param>
         /// <returns>A list of dynamic components from other templates.</returns>
         Task<List<DynamicContentOverviewModel>> GetLinkableDynamicContentAsync(int templateId);
-        
+
         /// <summary>
         /// Retrieve the variable data of a set version. This can be used for retrieving past versions or the current version if the version number is known.
         /// </summary>
@@ -34,17 +34,32 @@ namespace Api.Modules.Templates.Interfaces.DataLayer
         Task<KeyValuePair<string, Dictionary<string, object>>> GetComponentDataAsync(int contentId);
 
         /// <summary>
-        /// Save the given variables and their values as a new version in the database.
+        /// Get the ID, version number and published environment of the latest version of a component.
+        /// </summary>
+        /// <param name="contentId">The template ID.</param>
+        /// <param name="branchDatabaseName">When publishing in a different branch, enter the database name for that branch here.</param>
+        /// <returns>The ID, version number and published environment of the template.</returns>
+        Task<(int Id, int Version, Environments Environment)> GetLatestVersionAsync(int contentId, string branchDatabaseName = null);
+
+        /// <summary>
+        /// Updates the latest version of a template with new data. This method will overwrite this version, unless this version has been published to the live environment,
+        /// then it will create a new version as to not overwrite the live version.
         /// </summary>
         /// <param name="contentId">The ID of the dynamic content.</param>
         /// <param name="component">The type of component.</param>
         /// <param name="componentMode">The selected component mode.</param>
         /// <param name="title">The given name for the component.</param>
         /// <param name="settings">A dictionary of property names and their values.</param>
-        /// <param name="username">The name of the authenticated user.</param>
-        /// <returns>An int indicating the result of the executed query.</returns>
-        Task<int> SaveSettingsStringAsync(int contentId, string component, string componentMode, string title, Dictionary<string, object> settings, string username);
-        
+        /// <param name="username">The name of the authenticated user.</param>=
+        Task<int> SaveAsync(int contentId, string component, string componentMode, string title, Dictionary<string, object> settings, string username);
+
+        /// <summary>
+        /// Creates a new version of a dynamic component by copying the previous version and increasing the version number by one.
+        /// </summary>
+        /// <param name="contentId">The content ID of the dynamic component.</param>
+        /// <returns>The ID of the new version.</returns>
+        Task<int> CreateNewVersionAsync(int contentId);
+
         /// <summary>
         /// Save the given variables and their values as a new version in the database.
         /// </summary>
@@ -106,5 +121,10 @@ namespace Api.Modules.Templates.Interfaces.DataLayer
         /// <param name="dynamicContentIds">The IDs of the templates to deploy.</param>
         /// <param name="branchDatabaseName">The name of the database that contains the sub branch.</param>
         Task DeployToBranchAsync(List<int> dynamicContentIds, string branchDatabaseName);
+
+        /// <summary>
+        /// Function that makes sure that the database tables needed for components are up to date with the latest changes.
+        /// </summary>
+        Task KeepTablesUpToDateAsync();
     }
 }

--- a/Api/Modules/Templates/Interfaces/DataLayer/ITemplateDataService.cs
+++ b/Api/Modules/Templates/Interfaces/DataLayer/ITemplateDataService.cs
@@ -40,6 +40,14 @@ namespace Api.Modules.Templates.Interfaces.DataLayer
         Task<Dictionary<int, int>> GetPublishedEnvironmentsAsync(int templateId, string branchDatabaseName = null);
 
         /// <summary>
+        /// Get the ID, version number and published environment of the latest version of a template.
+        /// </summary>
+        /// <param name="templateId">The template ID.</param>
+        /// <param name="branchDatabaseName">When publishing in a different branch, enter the database name for that branch here.</param>
+        /// <returns>The ID, version number and published environment of the template.</returns>
+        Task<(int Id, int Version, Environments Environment)> GetLatestVersionAsync(int templateId, string branchDatabaseName = null);
+
+        /// <summary>
         /// Publish the template to an environment. This method will execute the publish model instructions it receives, logic for publishing linked environments should be handled in the servicelayer.
         /// </summary>
         /// <param name="templateId">The id of the template of which the environment should be published.</param>
@@ -50,21 +58,21 @@ namespace Api.Modules.Templates.Interfaces.DataLayer
         /// <param name="branchDatabaseName">When publishing in a different branch, enter the database name for that branch here.</param>
         /// <returns>An int confirming the rows altered by the query.</returns>
         Task<int> UpdatePublishedEnvironmentAsync(int templateId, int version, Environments environment, PublishLogModel publishLog, string username, string branchDatabaseName = null);
-        
+
         /// <summary>
         /// Get the templates linked to the current template and their relation to the current template.
         /// </summary>
         /// <param name="templateId">The id of the template which linked templates should be retrieved.</param>
         /// <returns>Return a list of linked templates in the form of linkedtemplatemodels.</returns>
         Task<List<LinkedTemplateModel>> GetLinkedTemplatesAsync(int templateId);
-        
+
         /// <summary>
         /// Get templates that can be linked to the current template but aren't linked yet.
         /// </summary>
         /// <param name="templateId">The id of the template for which the linkoptions should be retrieved.</param>
         /// <returns>A list of possible links in the form of linkedtemplatemodels.</returns>
         Task<List<LinkedTemplateModel>> GetTemplatesAvailableForLinkingAsync(int templateId);
-        
+
         /// <summary>
         /// Get dynamic content that is linked to the current template.
         /// </summary>
@@ -73,16 +81,24 @@ namespace Api.Modules.Templates.Interfaces.DataLayer
         Task<List<LinkedDynamicContentDao>> GetLinkedDynamicContentAsync(int templateId);
 
         /// <summary>
-        /// Saves the template data as a new version of the template.
+        /// Updates the latest version of a template with new data. This method will overwrite this version, unless this version has been published to the live environment,
+        /// then it will create a new version as to not overwrite the live version.
         /// </summary>
         /// <param name="templateSettings">A <see cref="TemplateSettingsModel"/> containing the new data to save as a new template version.</param>
         /// <param name="templateLinks">A comma separated list of all linked javascript/scss/css templates.</param>
         /// <param name="username">The name of the authenticated user.</param>
         /// <returns>An int confirming the affected rows of the query.</returns>
-        Task<int> SaveAsync(TemplateSettingsModel templateSettings, string templateLinks, string username);
-        
+        Task SaveAsync(TemplateSettingsModel templateSettings, string templateLinks, string username);
+
         /// <summary>
-        /// Retreives a section of the treeview around the given id. In case the id is 0 the root section of the tree will be retrieved.
+        /// Creates a new version of a template by copying the previous version and increasing the version number by one.
+        /// </summary>
+        /// <param name="templateId">The ID of the template to create a new version for.</param>
+        /// <returns>The ID of the new version.</returns>
+        Task<int> CreateNewVersionAsync(int templateId);
+
+        /// <summary>
+        /// Retrieves a section of the tree view around the given id. In case the id is 0 the root section of the tree will be retrieved.
         /// </summary>
         /// <param name="parentId">The id of the parent element of the treesection that needs to be retrieved</param>
         /// <returns>A list of templatetreeview items that are children of the given id.</returns>
@@ -153,7 +169,7 @@ namespace Api.Modules.Templates.Interfaces.DataLayer
         /// <param name="templateId">The ID of the SCSS template to get the includes/imports for.</param>
         /// <returns>A <see cref="StringBuilder"/> with the contents of all SCSS in the correct order.</returns>
         Task<StringBuilder> GetScssIncludesForScssTemplateAsync(int templateId);
-        
+
         /// <summary>
         /// Get all SCSS templates that are not include templates. These templates need to be recompiled when someone changes an include template.
         /// </summary>
@@ -182,5 +198,10 @@ namespace Api.Modules.Templates.Interfaces.DataLayer
         /// <param name="templateIds">The IDs of the templates to deploy.</param>
         /// <param name="branchDatabaseName">The name of the database that contains the sub branch.</param>
         Task DeployToBranchAsync(List<int> templateIds, string branchDatabaseName);
+
+        /// <summary>
+        /// Function that makes sure that the database tables needed for templates are up to date with the latest changes.
+        /// </summary>
+        Task KeepTablesUpToDateAsync();
     }
 }

--- a/Api/Modules/Templates/Interfaces/IDynamicContentService.cs
+++ b/Api/Modules/Templates/Interfaces/IDynamicContentService.cs
@@ -11,7 +11,7 @@ using GeeksCoreLibrary.Core.Enums;
 namespace Api.Modules.Templates.Interfaces
 {
     /// <summary>
-    /// The service containing the logic needed to use the models in a way the application will be able to process them. 
+    /// The service containing the logic needed to use the models in a way the application will be able to process them.
     /// This also forms the link with the dataservice for retrieving data from the database.
     /// </summary>
     public interface IDynamicContentService
@@ -22,7 +22,7 @@ namespace Api.Modules.Templates.Interfaces
         /// <param name="component">The type of the component from which the modes should be retrieved.</param>
         /// <returns>A dictionary containing the Key and (Display)name for each component mode.</returns>
         Dictionary<int, string> GetComponentModes(Type component);
-        
+
         /// <summary>
         /// Retrieve all component modes of a dynamic component.
         /// </summary>
@@ -46,7 +46,8 @@ namespace Api.Modules.Templates.Interfaces
         Task<ServiceResult<Dictionary<string, object>>> GetComponentDataAsync(int contentId);
 
         /// <summary>
-        /// Matches the component using reflection to retrieve its modes and saves the settings.
+        /// Updates the latest version of a template with new data. This method will overwrite this version, unless this version has been published to the live environment,
+        /// then it will create a new version as to not overwrite the live version.
         /// </summary>
         /// <param name="identity">The identity of the authenticated user.</param>
         /// <param name="contentId">The id of the content to save</param>
@@ -54,8 +55,16 @@ namespace Api.Modules.Templates.Interfaces
         /// <param name="componentMode">An int of the componentMode to match when the modes are retrieved</param>
         /// <param name="title">The name of the template to save</param>
         /// <param name="settings">A dictionary of settings containing their name and value</param>
-        /// <returns>An int with the new ID</returns>
-        Task<ServiceResult<int>> SaveNewSettingsAsync(ClaimsIdentity identity, int contentId, string component, int componentMode, string title, Dictionary<string, object> settings);
+        /// <returns>The ID of the component.</returns>
+        Task<ServiceResult<int>> SaveAsync(ClaimsIdentity identity, int contentId, string component, int componentMode, string title, Dictionary<string, object> settings);
+
+        /// <summary>
+        /// Creates a new version of a dynamic component by copying the previous version and increasing the version number by one.
+        /// </summary>
+        /// <param name="contentId">The content ID of the dynamic component.</param>
+        /// <param name="versionBeingDeployed">Optional: If calling this function while deploying the template to an environment, enter the version that is being deployed here. This will then check if that is the latest version and only create a new version of the template if that is the case.</param>
+        /// <returns>The ID of the new version.</returns>
+        Task<ServiceResult<int>> CreateNewVersionAsync(int contentId, int versionBeingDeployed = 0);
 
         /// <summary>
         /// Gets the meta data (name, component mode etc) for a component.
@@ -63,7 +72,7 @@ namespace Api.Modules.Templates.Interfaces
         /// <param name="contentId">The ID of the dynamic content.</param>
         /// <param name="includeSettings">Optional: Whether or not to include the settings that are saved with the component. Default value is <see langword="true" />.</param>
         Task<ServiceResult<DynamicContentOverviewModel>> GetMetaDataAsync(int contentId, bool includeSettings = true);
-        
+
         /// <summary>
         /// Links a dynamic content to a template.
         /// </summary>
@@ -71,16 +80,16 @@ namespace Api.Modules.Templates.Interfaces
         /// <param name="contentId">The ID of the dynamic content.</param>
         /// <param name="templateId">The ID of the template.</param>
         Task<ServiceResult<bool>> AddLinkToTemplateAsync(ClaimsIdentity identity, int contentId, int templateId);
-        
+
         /// <summary>
-        /// Get the dynamic component environments. This will retrieve a list of versions and their published environments and convert it to a PublishedEnvironmentModel 
+        /// Get the dynamic component environments. This will retrieve a list of versions and their published environments and convert it to a PublishedEnvironmentModel
         /// containing the Live, accept and test versions and the list of other versions that are present in the data.
         /// </summary>
         /// <param name="contentId">The id of the dynamic component to retrieve the environments of.</param>
         /// <param name="branchDatabaseName">When publishing in a different branch, enter the database name for that branch here.</param>
         /// <returns>A model containing the versions that are currently set for the live, accept and test environment.</returns>
         Task<ServiceResult<PublishedEnvironmentModel>> GetEnvironmentsAsync(int contentId, string branchDatabaseName = null);
-        
+
         /// <summary>
         /// Publish a dynamic component version to a new environment using a content/component id. This requires you to provide a model with the current published state.
         /// This method will use a generated change log to determine the environments that need to be changed. In some cases publishing an environment will also publish underlaying environments.
@@ -92,7 +101,7 @@ namespace Api.Modules.Templates.Interfaces
         /// <param name="currentPublished">A PublishedEnvironmentModel containing the current published templates.</param>
         /// <param name="branchDatabaseName">When publishing in a different branch, enter the database name for that branch here.</param>
         Task<ServiceResult<int>> PublishToEnvironmentAsync(ClaimsIdentity identity, int contentId, int version, Environments environment, PublishedEnvironmentModel currentPublished, string branchDatabaseName = null);
-        
+
         /// <summary>
         /// Duplicate a dynamic component (only the latest version).
         /// </summary>
@@ -107,7 +116,7 @@ namespace Api.Modules.Templates.Interfaces
         /// <param name="contentId">The id of the component</param>
         /// <returns></returns>
         Task<ServiceResult<bool>> DeleteAsync(int contentId);
-        
+
         /// <summary>
         /// Gets all dynamic content that can be linked to the given template.
         /// </summary>

--- a/Api/Modules/Templates/Interfaces/ITemplatesService.cs
+++ b/Api/Modules/Templates/Interfaces/ITemplatesService.cs
@@ -47,7 +47,7 @@ namespace Api.Modules.Templates.Interfaces
         /// <param name="templateName">The encrypted name of the wiser template.</param>
         /// <param name="requestPostData">Optional: The post data from the request, if the content type was application/x-www-form-urlencoded. This is for backwards compatibility.</param>
         Task<ServiceResult<JToken>> GetAndExecuteQueryAsync(ClaimsIdentity identity, string templateName, IFormCollection requestPostData = null);
-        
+
         /// <summary>
         /// Gets the CSS that should be used for HTML editors, so that their content will look more like how it would look on the customer's website.
         /// </summary>
@@ -80,28 +80,28 @@ namespace Api.Modules.Templates.Interfaces
         Task<ServiceResult<TemplateSettingsModel>> GetTemplateSettingsAsync(ClaimsIdentity identity, int templateId, Environments? environment = null);
 
         /// <summary>
-        /// Get the template environments. This will retrieve a list of versions and their published environments and convert it to a PublishedEnvironmentModel 
+        /// Get the template environments. This will retrieve a list of versions and their published environments and convert it to a PublishedEnvironmentModel
         /// containing the Live, accept and test versions and the list of other versions that are present in the data.
         /// </summary>
         /// <param name="templateId">The id of the template to retrieve the environments of.</param>
         /// <param name="branchDatabaseName">When publishing in a different branch, enter the database name for that branch here.</param>
         /// <returns>A model containing the versions that are currently set for the live, accept and test environment.</returns>
         Task<ServiceResult<PublishedEnvironmentModel>> GetTemplateEnvironmentsAsync(int templateId, string branchDatabaseName = null);
-        
+
         /// <summary>
         /// Get the templates linked to the current template. The templates that are retrieved will be converted into a LinkedTemplatesModel using the LinkedTemplatesEnum to determine its link type.
         /// </summary>
         /// <param name="templateId">The id of the template of which to retrieve the linked templates.</param>
         /// <returns>A LinkedTemplates model that contains several lists of linked templates divided by their link type. (e.g. javascript, css)</returns>
         Task<ServiceResult<LinkedTemplatesModel>> GetLinkedTemplatesAsync(int templateId);
-        
+
         /// <summary>
         /// Get the dynamic content that is linked to the current template. This method will convert the linked dynamic content data into a dynamic content overview which can be used for displaying a general overview of the dynamic content.
         /// </summary>
         /// <param name="templateId">The id of the template to of which to retrieve the linked dynamic content.</param>
         /// <returns>A list of overviews for dynamic content. All content in the list is linked to the current template.</returns>
         Task<ServiceResult<List<DynamicContentOverviewModel>>> GetLinkedDynamicContentAsync(int templateId);
-        
+
         /// <summary>
         /// Publish a template version to a new environment using a template id. This requires you to provide a model with the current published state.
         /// This method will use a generated change log to determine the environments that need to be changed. In some cases publishing an environment will also publish underlaying environments.
@@ -116,13 +116,22 @@ namespace Api.Modules.Templates.Interfaces
         Task<ServiceResult<int>> PublishToEnvironmentAsync(ClaimsIdentity identity, int templateId, int version, Environments environment, PublishedEnvironmentModel currentPublished, string branchDatabaseName = null);
 
         /// <summary>
-        /// Save the template as a new version and save the linked templates if necessary. This method will calculate if links are to be added or removed from the current situation.
+        /// Updates the latest version of a template with new data. This method will overwrite this version, unless this version has been published to the live environment,
+        /// then it will create a new version as to not overwrite the live version.
         /// </summary>
         /// <param name="identity">The identity of the authenticated user.</param>
         /// <param name="template">A <see cref="TemplateSettingsModel"/> containing the data of the template that is to be saved as a new version</param>
         /// <param name="skipCompilation">Optional: Whether or not to skip the compilations of SCSS templates. Default value is <see langword="false" />.</param>
-        Task<ServiceResult<bool>> SaveTemplateVersionAsync(ClaimsIdentity identity, TemplateSettingsModel template, bool skipCompilation = false);
-        
+        Task<ServiceResult<bool>> SaveAsync(ClaimsIdentity identity, TemplateSettingsModel template, bool skipCompilation = false);
+
+        /// <summary>
+        /// Creates a new version of a template by copying the previous version and increasing the version number by one.
+        /// </summary>
+        /// <param name="templateId">The ID of the template to create a new version for.</param>
+        /// <param name="versionBeingDeployed">Optional: If calling this function while deploying the template to an environment, enter the version that is being deployed here. This will then check if that is the latest version and only create a new version of the template if that is the case.</param>
+        /// <returns>The ID of the new version.</returns>
+        Task<ServiceResult<int>> CreateNewVersionAsync(int templateId, int versionBeingDeployed = 0);
+
         /// <summary>
         /// Retrieve the tree view section underlying the parentId. Transforms the tree view section into a list of TemplateTreeViewModels.
         /// </summary>
@@ -262,7 +271,7 @@ namespace Api.Modules.Templates.Interfaces
         /// <param name="componentId">The ID of the dynamic content to save the settings for.</param>
         /// <param name="settings">The new settings.</param>
         Task<ServiceResult<bool>> SaveMeasurementSettingsAsync(MeasurementSettings settings, int templateId = 0, int componentId = 0);
-        
+
         /// <summary>
         /// Get rendering logs from database, filtered by the parameters.
         /// </summary>
@@ -280,7 +289,7 @@ namespace Api.Modules.Templates.Interfaces
         /// <returns>A list of <see cref="RenderLogModel"/> with the results.</returns>
         Task<ServiceResult<List<RenderLogModel>>> GetRenderLogsAsync(int templateId, int version = 0,
             string urlRegex = null, Environments? environment = null, ulong userId = 0,
-            string languageCode = null, int pageSize = 500, int pageNumber = 1, 
+            string languageCode = null, int pageSize = 500, int pageNumber = 1,
             bool getDailyAverage = false, DateTime? start = null, DateTime? end = null);
     }
 }

--- a/Api/Modules/Templates/Models/Other/Constants.cs
+++ b/Api/Modules/Templates/Models/Other/Constants.cs
@@ -1,0 +1,16 @@
+﻿namespace Api.Modules.Templates.Models.Other;
+
+/// <summary>
+/// Constants for the templates module.
+/// </summary>
+public static class Constants
+{
+    /// <summary>
+    /// Name for wiser_table_changes to keep track of whether we've set the is_dirty flag to true for templates.
+    /// </summary>
+    public const string SetIsDirtyToTemplates = "set_is_dirty_to_templates";
+    /// <summary>
+    /// Name for wiser_table_changes to keep track of whether we've set the is_dirty flag to true for components.
+    /// </summary>
+    public const string SetIsDirtyToComponents = "set_is_dirty_to_components";
+}

--- a/Api/Modules/Templates/Services/CachedTemplatesService.cs
+++ b/Api/Modules/Templates/Services/CachedTemplatesService.cs
@@ -118,9 +118,15 @@ namespace Api.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public async Task<ServiceResult<bool>> SaveTemplateVersionAsync(ClaimsIdentity identity, TemplateSettingsModel template, bool skipCompilation = false)
+        public async Task<ServiceResult<bool>> SaveAsync(ClaimsIdentity identity, TemplateSettingsModel template, bool skipCompilation = false)
         {
-            return await templatesService.SaveTemplateVersionAsync(identity, template, skipCompilation);
+            return await templatesService.SaveAsync(identity, template, skipCompilation);
+        }
+
+        /// <inheritdoc />
+        public async Task<ServiceResult<int>> CreateNewVersionAsync(int templateId, int versionBeingDeployed = 0)
+        {
+            return await templatesService.CreateNewVersionAsync(templateId, versionBeingDeployed);
         }
 
         /// <inheritdoc />

--- a/Api/Modules/Templates/Services/DataLayer/DynamicContentDataService.cs
+++ b/Api/Modules/Templates/Services/DataLayer/DynamicContentDataService.cs
@@ -5,11 +5,13 @@ using System.Linq;
 using System.Threading.Tasks;
 using Api.Modules.Templates.Interfaces.DataLayer;
 using Api.Modules.Templates.Models.DynamicContent;
+using Api.Modules.Templates.Models.Other;
 using Api.Modules.Templates.Models.Template;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Enums;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
+using GeeksCoreLibrary.Modules.Templates.Enums;
 using Newtonsoft.Json;
 
 namespace Api.Modules.Templates.Services.DataLayer
@@ -17,20 +19,22 @@ namespace Api.Modules.Templates.Services.DataLayer
     /// <inheritdoc cref="IDynamicContentDataService" />
     public class DynamicContentDataService : IDynamicContentDataService, IScopedService
     {
-        private readonly IDatabaseConnection connection;
+        private readonly IDatabaseConnection clientDatabaseConnection;
+        private readonly IDatabaseHelpersService databaseHelpersService;
 
         /// <summary>
         /// Creates a new instance of <see cref="DynamicContentDataService"/>.
         /// </summary>
-        public DynamicContentDataService(IDatabaseConnection connection)
+        public DynamicContentDataService(IDatabaseConnection clientDatabaseConnection, IDatabaseHelpersService databaseHelpersService)
         {
-            this.connection = connection;
+            this.clientDatabaseConnection = clientDatabaseConnection;
+            this.databaseHelpersService = databaseHelpersService;
         }
 
         /// <inheritdoc />
         public async Task<List<DynamicContentOverviewModel>> GetLinkableDynamicContentAsync(int templateId)
         {
-            connection.AddParameter("templateId", templateId);
+            clientDatabaseConnection.AddParameter("templateId", templateId);
             var query = $@"SELECT
 	component.content_id,
 	component.title,
@@ -40,7 +44,7 @@ namespace Api.Modules.Templates.Services.DataLayer
 FROM {WiserTableNames.WiserDynamicContent} AS component
 LEFT JOIN {WiserTableNames.WiserDynamicContent} AS otherVersion ON otherVersion.content_id = component.content_id AND otherVersion.version > component.version
 LEFT JOIN {WiserTableNames.WiserTemplateDynamicContent} AS linkToTemplate ON linkToTemplate.content_id = component.content_id
-LEFT JOIN {WiserTableNames.WiserTemplate} AS template ON template.template_id = linkToTemplate.destination_template_id AND template.template_type = 1 AND template.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = linkToTemplate.destination_template_id)
+LEFT JOIN {WiserTableNames.WiserTemplate} AS template ON template.template_id = linkToTemplate.destination_template_id AND template.template_type = {(int)TemplateTypes.Html} AND template.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = linkToTemplate.destination_template_id)
 LEFT JOIN {WiserTableNames.WiserTemplate} AS parent1 ON parent1.template_id = template.parent_id AND parent1.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = template.parent_id)
 LEFT JOIN {WiserTableNames.WiserTemplate} AS parent2 ON parent2.template_id = parent1.parent_id AND parent2.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = parent1.parent_id)
 LEFT JOIN {WiserTableNames.WiserTemplate} AS parent3 ON parent3.template_id = parent2.parent_id AND parent3.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = parent2.parent_id)
@@ -50,7 +54,7 @@ WHERE otherVersion.id IS NULL
 AND (linkToTemplate.id IS NULL OR linkToTemplate.destination_template_id <> ?templateId)
 ORDER BY templatePath ASC, component.title ASC";
 
-            var dataTable = await connection.GetAsync(query);
+            var dataTable = await clientDatabaseConnection.GetAsync(query);
             var results = dataTable.Rows.Cast<DataRow>().Select(dataRow => new DynamicContentOverviewModel
             {
                 Id = dataRow.Field<int>("content_id"),
@@ -66,17 +70,17 @@ ORDER BY templatePath ASC, component.title ASC";
         /// <inheritdoc />
         public async Task<KeyValuePair<string, Dictionary<string, object>>> GetVersionDataAsync(int version, int contentId)
         {
-            connection.ClearParameters();
-            connection.AddParameter("version", version);
-            connection.AddParameter("contentId", contentId);
-            var dataTable = await connection.GetAsync($"SELECT wdc.settings, wdc.`title` FROM {WiserTableNames.WiserDynamicContent} wdc WHERE wdc.content_id = ?contentId AND wdc.version = ?version AND removed = 0 ORDER BY wdc.version DESC LIMIT 1");
+            clientDatabaseConnection.ClearParameters();
+            clientDatabaseConnection.AddParameter("version", version);
+            clientDatabaseConnection.AddParameter("contentId", contentId);
+            var dataTable = await clientDatabaseConnection.GetAsync($"SELECT wdc.settings, wdc.`title` FROM {WiserTableNames.WiserDynamicContent} wdc WHERE wdc.content_id = ?contentId AND wdc.version = ?version AND removed = 0 ORDER BY wdc.version DESC LIMIT 1");
 
             var settings = dataTable.Rows[0].Field<string>("settings") ?? "{}";
             var title = dataTable.Rows[0].Field<string>("title");
 
             return new KeyValuePair<string, Dictionary<string, object>>(title, JsonConvert.DeserializeObject<Dictionary<string, object>>(settings));
         }
-        
+
         /// <inheritdoc />
         public async Task<KeyValuePair<string, Dictionary<string, object>>> GetComponentDataAsync(int contentId)
         {
@@ -84,40 +88,115 @@ ORDER BY templatePath ASC, component.title ASC";
 
             return new KeyValuePair<string, Dictionary<string, object>>(rawData.Key, JsonConvert.DeserializeObject<Dictionary<string, object>>(rawData.Value));
         }
-        
+
         /// <inheritdoc />
-        public async Task<int> SaveSettingsStringAsync(int contentId, string component, string componentMode, string title, Dictionary<string, object> settings, string username)
+        public async Task<(int Id, int Version, Environments Environment)> GetLatestVersionAsync(int contentId, string branchDatabaseName = null)
         {
-            if (contentId <= 0)
+            var databaseNamePrefix = String.IsNullOrWhiteSpace(branchDatabaseName) ? "" : $"`{branchDatabaseName}`.";
+
+            // Get the ID and published environment of the latest version of the component.
+            var query = $@"SELECT 
+    component.id,
+    component.version,
+    component.published_environment
+FROM {databaseNamePrefix}{WiserTableNames.WiserDynamicContent} AS component
+LEFT JOIN {databaseNamePrefix}{WiserTableNames.WiserDynamicContent} AS otherVersion ON otherVersion.content_id = component.content_id AND otherVersion.version > component.version
+WHERE component.content_id = ?contentId
+AND otherVersion.id IS NULL";
+            clientDatabaseConnection.AddParameter("contentId", contentId);
+            var dataTable = await clientDatabaseConnection.GetAsync(query);
+            if (dataTable.Rows.Count == 0)
             {
-                var dataTable = await connection.GetAsync($"SELECT IFNULL(MAX(content_id), 0) AS max_content_id FROM {WiserTableNames.WiserDynamicContent}");
-                contentId = (dataTable.Rows.Count == 0 ? 0 : Convert.ToInt32(dataTable.Rows[0]["max_content_id"])) + 1;
+                throw new Exception($"Template with ID {contentId} not found.");
             }
 
-            connection.ClearParameters();
-            connection.AddParameter("settings", JsonConvert.SerializeObject(settings));
-            connection.AddParameter("component", component);
-            connection.AddParameter("componentMode", componentMode);
-            connection.AddParameter("contentId", contentId);
-            connection.AddParameter("title", title);
-            connection.AddParameter("now", DateTime.Now);
-            connection.AddParameter("username", username);
+            var id = Convert.ToInt32(dataTable.Rows[0]["id"]);
+            var version = Convert.ToInt32(dataTable.Rows[0]["version"]);
+            var publishedEnvironment = (Environments)Convert.ToInt32(dataTable.Rows[0]["published_environment"]);
+            return (id, version, publishedEnvironment);
+        }
 
-            await connection.InsertRecordAsync($@"
-            SET @VersionNumber = IFNULL((SELECT MAX(version)+1 FROM {WiserTableNames.WiserDynamicContent} WHERE content_id = ?contentId GROUP BY content_id), 1);
+        /// <inheritdoc />
+        public async Task<int> SaveAsync(int contentId, string component, string componentMode, string title, Dictionary<string, object> settings, string username)
+        {
+            string query;
+            if (contentId <= 0)
+            {
+                var dataTable = await clientDatabaseConnection.GetAsync($"SELECT IFNULL(MAX(content_id), 0) AS max_content_id FROM {WiserTableNames.WiserDynamicContent}");
+                contentId = (dataTable.Rows.Count == 0 ? 0 : Convert.ToInt32(dataTable.Rows[0]["max_content_id"])) + 1;
+                clientDatabaseConnection.AddParameter("contentId", contentId);
 
-            INSERT INTO {WiserTableNames.WiserDynamicContent} (`version`, `changed_on`, `changed_by`, `settings`, `content_id`, `component`, `component_mode`, `title`) 
-            VALUES (@VersionNumber, ?now, ?username, ?settings, ?contentId, ?component, ?componentMode, ?title)");
+                query = $@"INSERT INTO {WiserTableNames.WiserDynamicContent} (`version`, `changed_on`, `changed_by`, `settings`, `content_id`, `component`, `component_mode`, `title`, `is_dirty`) 
+VALUES (1, ?now, ?username, ?settings, ?contentId, ?component, ?componentMode, ?title, TRUE)";
+            }
+            else
+            {
+                clientDatabaseConnection.AddParameter("contentId", contentId);
+                // Get the ID and published environment of the latest version of the component.
+                var latestVersion = await GetLatestVersionAsync(contentId);
 
+                // If the latest version is published to live, create a new version, because we never want to edit the version that is published to live directly.
+                if ((latestVersion.Environment & Environments.Live) == Environments.Live)
+                {
+                    latestVersion.Id = await CreateNewVersionAsync(contentId);
+                }
+
+                clientDatabaseConnection.AddParameter("id", latestVersion.Id);
+                query = $@"UPDATE {WiserTableNames.WiserDynamicContent} 
+SET `changed_on` = ?now, 
+    `changed_by` = ?username, 
+    `settings` = ?settings, 
+    `component` = ?component, 
+    `component_mode` = ?componentMode, 
+    `title` = ?title,
+    `is_dirty` = TRUE
+WHERE id = ?id";
+            }
+
+            clientDatabaseConnection.AddParameter("settings", JsonConvert.SerializeObject(settings));
+            clientDatabaseConnection.AddParameter("component", component);
+            clientDatabaseConnection.AddParameter("componentMode", componentMode);
+            clientDatabaseConnection.AddParameter("title", title);
+            clientDatabaseConnection.AddParameter("now", DateTime.Now);
+            clientDatabaseConnection.AddParameter("username", username);
+
+            await clientDatabaseConnection.ExecuteAsync(query);
             return contentId;
         }
-        
+
+        /// <inheritdoc />
+        public async Task<int> CreateNewVersionAsync(int contentId)
+        {
+            clientDatabaseConnection.ClearParameters();
+            clientDatabaseConnection.AddParameter("contentId", contentId);
+            clientDatabaseConnection.AddParameter("now", DateTime.Now);
+
+            var query = $@"INSERT INTO {WiserTableNames.WiserDynamicContent} (`version`, `changed_on`, `changed_by`, `settings`, `content_id`, `component`, `component_mode`, `title`, `is_dirty`) 
+SELECT
+    component.version + 1 AS version,
+    ?now AS changed_on,
+    'Wiser' AS changed_by,
+    component.settings,
+    component.content_id,
+    component.component,
+    component.component_mode,
+    component.title,
+    FALSE AS is_dirty
+FROM {WiserTableNames.WiserDynamicContent} AS component
+LEFT JOIN {WiserTableNames.WiserDynamicContent} AS otherVersion ON otherVersion.content_id = component.content_id AND otherVersion.version > component.version
+WHERE component.content_id = ?contentId
+AND otherVersion.id IS NULL";
+
+            var newId = await clientDatabaseConnection.InsertRecordAsync(query);
+            return Convert.ToInt32(newId);
+        }
+
         /// <inheritdoc />
         public async Task<List<string>> GetComponentAndModeFromContentIdAsync(int contentId)
         {
-            connection.ClearParameters();
-            connection.AddParameter("id", contentId);
-            var dataTable = await connection.GetAsync($"SELECT wdc.component, wdc.component_mode FROM {WiserTableNames.WiserDynamicContent} wdc WHERE id = ?id LIMIT 1");
+            clientDatabaseConnection.ClearParameters();
+            clientDatabaseConnection.AddParameter("id", contentId);
+            var dataTable = await clientDatabaseConnection.GetAsync($"SELECT wdc.component, wdc.component_mode FROM {WiserTableNames.WiserDynamicContent} wdc WHERE id = ?id LIMIT 1");
 
             var results = new List<string>
             {
@@ -131,21 +210,21 @@ ORDER BY templatePath ASC, component.title ASC";
         /// <inheritdoc />
         public async Task<DynamicContentOverviewModel> GetMetaDataAsync(int contentId)
         {
-            connection.ClearParameters();
-            connection.AddParameter("contentId", contentId);
-            var dataTable = await connection.GetAsync($@"SELECT
-                                                            component.id,
-                                                            component.component,
-                                                            component.component_mode,
-                                                            component.version,
-                                                            component.title,
-                                                            component.changed_on,
-                                                            component.changed_by
-                                                        FROM {WiserTableNames.WiserDynamicContent} AS component
-                                                        WHERE component.content_id = ?contentId
-                                                        AND component.removed = 0
-                                                        ORDER BY component.version DESC
-                                                        LIMIT 1");
+            clientDatabaseConnection.ClearParameters();
+            clientDatabaseConnection.AddParameter("contentId", contentId);
+            var dataTable = await clientDatabaseConnection.GetAsync($@"SELECT
+    component.id,
+    component.component,
+    component.component_mode,
+    component.version,
+    component.title,
+    component.changed_on,
+    component.changed_by
+FROM {WiserTableNames.WiserDynamicContent} AS component
+WHERE component.content_id = ?contentId
+AND component.removed = 0
+ORDER BY component.version DESC
+LIMIT 1");
 
             return dataTable.Rows.Count == 0 ? null : new DynamicContentOverviewModel
             {
@@ -158,28 +237,28 @@ ORDER BY templatePath ASC, component.title ASC";
                 ChangedBy = dataTable.Rows[0].Field<string>("changed_by")
             };
         }
-        
+
         /// <inheritdoc />
         public async Task AddLinkToTemplateAsync(int contentId, int templateId, string username)
         {
-            connection.ClearParameters();
-            connection.AddParameter("contentId", contentId);
-            connection.AddParameter("templateId", templateId);
-            connection.AddParameter("now", DateTime.Now);
-            connection.AddParameter("username", username);
-            await connection.ExecuteAsync($@"INSERT IGNORE INTO {WiserTableNames.WiserTemplateDynamicContent} (content_id, destination_template_id, added_on, added_by)
+            clientDatabaseConnection.ClearParameters();
+            clientDatabaseConnection.AddParameter("contentId", contentId);
+            clientDatabaseConnection.AddParameter("templateId", templateId);
+            clientDatabaseConnection.AddParameter("now", DateTime.Now);
+            clientDatabaseConnection.AddParameter("username", username);
+            await clientDatabaseConnection.ExecuteAsync($@"INSERT IGNORE INTO {WiserTableNames.WiserTemplateDynamicContent} (content_id, destination_template_id, added_on, added_by)
                                                 VALUES (?contentId, ?templateId, ?now, ?username)");
         }
 
         /// <inheritdoc />
         public async Task<Dictionary<int, int>> GetPublishedEnvironmentsAsync(int contentId, string branchDatabaseName = null)
         {
-            connection.ClearParameters();
-            connection.AddParameter("contentId", contentId);
+            clientDatabaseConnection.ClearParameters();
+            clientDatabaseConnection.AddParameter("contentId", contentId);
             var versionList = new Dictionary<int, int>();
 
             var databaseNamePrefix = String.IsNullOrWhiteSpace(branchDatabaseName) ? "" : $"`{branchDatabaseName}`.";
-            var dataTable = await connection.GetAsync($"SELECT version, published_environment FROM {databaseNamePrefix}{WiserTableNames.WiserDynamicContent} WHERE content_id = ?contentId AND removed = 0");
+            var dataTable = await clientDatabaseConnection.GetAsync($"SELECT version, published_environment FROM {databaseNamePrefix}{WiserTableNames.WiserDynamicContent} WHERE content_id = ?contentId AND removed = 0");
 
             foreach (DataRow row in dataTable.Rows)
             {
@@ -205,19 +284,19 @@ ORDER BY templatePath ASC, component.title ASC";
                     break;
             }
 
-            connection.AddParameter("contentId", contentId);
-            connection.AddParameter("version", version);
-            connection.AddParameter("environment", (int)environment);
+            clientDatabaseConnection.AddParameter("contentId", contentId);
+            clientDatabaseConnection.AddParameter("version", version);
+            clientDatabaseConnection.AddParameter("environment", (int)environment);
 
             var databaseNamePrefix = String.IsNullOrWhiteSpace(branchDatabaseName) ? "" : $"`{branchDatabaseName}`.";
-            
+
             // Add the bit of the selected environment to the selected version.
             var query = $@"UPDATE {databaseNamePrefix}{WiserTableNames.WiserDynamicContent}
 SET published_environment = published_environment | ?environment
 WHERE content_id = ?contentId
 AND version = ?version";
-            var affectedRows = await connection.ExecuteAsync(query);
-            
+            var affectedRows = await clientDatabaseConnection.ExecuteAsync(query);
+
             // Query to remove the selected environment from all other versions, the ~ operator flips all the bits (1s become 0s and 0s become 1s).
             // This way we can safely turn off just the specific bits without having to check to see if the bit is set.
             query = $@"UPDATE {databaseNamePrefix}{WiserTableNames.WiserDynamicContent}
@@ -225,21 +304,21 @@ SET published_environment = published_environment & ~?environment
 WHERE content_id = ?contentId
 AND version != ?version";
 
-            affectedRows += await connection.ExecuteAsync(query);
+            affectedRows += await clientDatabaseConnection.ExecuteAsync(query);
 
             if (affectedRows == 0)
             {
                 return affectedRows;
             }
-            
-            connection.AddParameter("oldlive", publishLog.OldLive);
-            connection.AddParameter("oldaccept", publishLog.OldAccept);
-            connection.AddParameter("oldtest", publishLog.OldTest);
-            connection.AddParameter("newlive", publishLog.NewLive);
-            connection.AddParameter("newaccept", publishLog.NewAccept);
-            connection.AddParameter("newtest", publishLog.NewTest);
-            connection.AddParameter("now", DateTime.Now);
-            connection.AddParameter("username", username);
+
+            clientDatabaseConnection.AddParameter("oldlive", publishLog.OldLive);
+            clientDatabaseConnection.AddParameter("oldaccept", publishLog.OldAccept);
+            clientDatabaseConnection.AddParameter("oldtest", publishLog.OldTest);
+            clientDatabaseConnection.AddParameter("newlive", publishLog.NewLive);
+            clientDatabaseConnection.AddParameter("newaccept", publishLog.NewAccept);
+            clientDatabaseConnection.AddParameter("newtest", publishLog.NewTest);
+            clientDatabaseConnection.AddParameter("now", DateTime.Now);
+            clientDatabaseConnection.AddParameter("username", username);
 
             query = $@"INSERT INTO {databaseNamePrefix}{WiserTableNames.WiserDynamicContentPublishLog}
 (
@@ -266,15 +345,15 @@ VALUES
     ?username
 )";
 
-            return await connection.ExecuteAsync(query);
+            return await clientDatabaseConnection.ExecuteAsync(query);
         }
 
         /// <inheritdoc />
         public async Task DuplicateAsync(int contentId, int newTemplateId, string username)
         {
-            var dataTable = await connection.GetAsync($"SELECT IFNULL(MAX(content_id), 0) AS max_content_id FROM {WiserTableNames.WiserDynamicContent}");
+            var dataTable = await clientDatabaseConnection.GetAsync($"SELECT IFNULL(MAX(content_id), 0) AS max_content_id FROM {WiserTableNames.WiserDynamicContent}");
             var newContentId = (dataTable.Rows.Count == 0 ? 0 : Convert.ToInt32(dataTable.Rows[0]["max_content_id"])) + 1;
-            
+
             var query = $@"INSERT INTO {WiserTableNames.WiserDynamicContent}
 (
     content_id,
@@ -305,22 +384,22 @@ AND otherVersion.id IS NULL;
 
 INSERT INTO {WiserTableNames.WiserTemplateDynamicContent} (content_id, destination_template_id, added_on, added_by)
 VALUES (?newContentId, ?templateId, ?now, ?username);";
-            
-            connection.AddParameter("contentId", contentId);
-            connection.AddParameter("newContentId", newContentId);
-            connection.AddParameter("now", DateTime.Now);
-            connection.AddParameter("username", username);
-            connection.AddParameter("templateId", newTemplateId);
-            await connection.ExecuteAsync(query);
+
+            clientDatabaseConnection.AddParameter("contentId", contentId);
+            clientDatabaseConnection.AddParameter("newContentId", newContentId);
+            clientDatabaseConnection.AddParameter("now", DateTime.Now);
+            clientDatabaseConnection.AddParameter("username", username);
+            clientDatabaseConnection.AddParameter("templateId", newTemplateId);
+            await clientDatabaseConnection.ExecuteAsync(query);
         }
 
         /// <inheritdoc />
         public async Task DeleteAsync(int contentId)
         {
-            connection.ClearParameters();
-            connection.AddParameter("contentId", contentId);
+            clientDatabaseConnection.ClearParameters();
+            clientDatabaseConnection.AddParameter("contentId", contentId);
             var query = $@"UPDATE {WiserTableNames.WiserDynamicContent} SET removed = 1 WHERE content_id = ?contentID";
-            await connection.ExecuteAsync(query);
+            await clientDatabaseConnection.ExecuteAsync(query);
         }
 
         /// <inheritdoc />
@@ -333,21 +412,56 @@ FROM {WiserTableNames.WiserDynamicContent} AS content
 LEFT JOIN {WiserTableNames.WiserDynamicContent} AS otherVersion ON otherVersion.content_id = content.content_id AND otherVersion.version > content.version
 WHERE content.content_id IN ({String.Join(", ", dynamicContentIds)})
 AND otherVersion.id IS NULL";
-            await connection.ExecuteAsync(query);
-            
+            await clientDatabaseConnection.ExecuteAsync(query);
+
             // Also copy all links of dynamic content to template to the branch.
             query = $@"INSERT IGNORE INTO `{branchDatabaseName}`.{WiserTableNames.WiserTemplateDynamicContent}
 SELECT *
 FROM {WiserTableNames.WiserTemplateDynamicContent}
 WHERE content_id IN ({String.Join(", ", dynamicContentIds)});";
-            await connection.ExecuteAsync(query);
+            await clientDatabaseConnection.ExecuteAsync(query);
+        }
+
+        /// <inheritdoc />
+        public async Task KeepTablesUpToDateAsync()
+        {
+            var lastTableUpdates = await databaseHelpersService.GetLastTableUpdatesAsync(clientDatabaseConnection.ConnectedDatabase);
+
+            // Check if the components table needs to be updated.
+            if ((lastTableUpdates.TryGetValue(Constants.SetIsDirtyToComponents, out var value) && value >= new DateTime(2023, 7, 4)))
+            {
+                return;
+            }
+
+            var query = $@"UPDATE {WiserTableNames.WiserDynamicContent} AS component
+LEFT JOIN {WiserTableNames.WiserDynamicContent} AS otherVersion ON otherVersion.content_id = component.content_id AND otherVersion.version > component.version
+LEFT JOIN {WiserTableNames.WiserCommitDynamicContent} AS componentCommit ON componentCommit.dynamic_content_id = component.content_id AND componentCommit.version = component.version
+SET component.is_dirty = TRUE
+WHERE component.removed = 0
+AND component.is_dirty = FALSE
+AND otherVersion.id IS NULL
+AND componentCommit.id IS NULL";
+            await clientDatabaseConnection.ExecuteAsync(query);
+
+            clientDatabaseConnection.ClearParameters();
+            clientDatabaseConnection.AddParameter("tableName", Constants.SetIsDirtyToComponents);
+            clientDatabaseConnection.AddParameter("lastUpdate", DateTime.Now);
+            var lastUpdateData = await clientDatabaseConnection.GetAsync($"SELECT NULL FROM `{WiserTableNames.WiserTableChanges}` WHERE `name` = ?tableName");
+            if (lastUpdateData.Rows.Count == 0)
+            {
+                await clientDatabaseConnection.ExecuteAsync($"INSERT INTO `{WiserTableNames.WiserTableChanges}` (`name`, last_update) VALUES (?tableName, ?lastUpdate)");
+            }
+            else
+            {
+                await clientDatabaseConnection.ExecuteAsync($"UPDATE `{WiserTableNames.WiserTableChanges}` SET last_update = ?lastUpdate WHERE `name` = ?tableName LIMIT 1");
+            }
         }
 
         private async Task<KeyValuePair<string, string>> GetDatabaseData(int contentId)
         {
-            connection.ClearParameters();
-            connection.AddParameter("contentId", contentId);
-            var dataTable = await connection.GetAsync($@"SELECT settings, title, removed FROM {WiserTableNames.WiserDynamicContent} WHERE content_id = ?contentId ORDER BY version DESC LIMIT 1");
+            clientDatabaseConnection.ClearParameters();
+            clientDatabaseConnection.AddParameter("contentId", contentId);
+            var dataTable = await clientDatabaseConnection.GetAsync($@"SELECT settings, title, removed FROM {WiserTableNames.WiserDynamicContent} WHERE content_id = ?contentId ORDER BY version DESC LIMIT 1");
             if (Convert.ToBoolean(dataTable.Rows[0]["removed"]))
             {
                 return new KeyValuePair<string, string>(null, null);

--- a/Api/Modules/Templates/Services/HistoryService.cs
+++ b/Api/Modules/Templates/Services/HistoryService.cs
@@ -76,7 +76,7 @@ namespace Api.Modules.Templates.Services
             }
 
             var componentAndMode = await dataService.GetComponentAndModeFromContentIdAsync(contentId);
-            await dataService.SaveSettingsStringAsync(contentId, componentAndMode[0], componentAndMode[1], currentVersion.Key, currentVersion.Value, IdentityHelpers.GetUserName(identity, true));
+            await dataService.SaveAsync(contentId, componentAndMode[0], componentAndMode[1], currentVersion.Key, currentVersion.Value, IdentityHelpers.GetUserName(identity, true));
             return new ServiceResult<int>
             {
                 StatusCode = HttpStatusCode.NoContent

--- a/Api/Modules/Templates/Services/TemplatesService.cs
+++ b/Api/Modules/Templates/Services/TemplatesService.cs
@@ -56,6 +56,7 @@ using MySql.Data.MySqlClient;
 using Newtonsoft.Json.Linq;
 using NUglify;
 using NUglify.JavaScript;
+using Constants = GeeksCoreLibrary.Modules.Templates.Models.Constants;
 using ITemplatesService = Api.Modules.Templates.Interfaces.ITemplatesService;
 
 namespace Api.Modules.Templates.Services
@@ -87,6 +88,7 @@ namespace Api.Modules.Templates.Services
         private readonly IWebHostEnvironment webHostEnvironment;
         private readonly IBranchesService branchesService;
         private readonly IMeasurementsDataService measurementsDataService;
+        private readonly IDynamicContentDataService dynamicContentDataService;
 
         /// <summary>
         /// Creates a new instance of TemplatesService.
@@ -110,7 +112,8 @@ namespace Api.Modules.Templates.Services
             IOptions<ApiSettings> apiSettings,
             IWebHostEnvironment webHostEnvironment,
             IBranchesService branchesService,
-            IMeasurementsDataService measurementsDataService)
+            IMeasurementsDataService measurementsDataService,
+            IDynamicContentDataService dynamicContentDataService)
         {
             this.httpContextAccessor = httpContextAccessor;
             this.wiserCustomersService = wiserCustomersService;
@@ -132,6 +135,7 @@ namespace Api.Modules.Templates.Services
             this.webHostEnvironment = webHostEnvironment;
             this.branchesService = branchesService;
             this.measurementsDataService = measurementsDataService;
+            this.dynamicContentDataService = dynamicContentDataService;
 
             if (clientDatabaseConnection is ClientDatabaseConnection connection)
             {
@@ -239,7 +243,7 @@ namespace Api.Modules.Templates.Services
 FROM {WiserTableNames.WiserTemplate} AS template
 LEFT JOIN {WiserTableNames.WiserTemplate} AS otherVersion ON otherVersion.template_id = template.template_id AND otherVersion.version > template.version
 WHERE (template.use_in_wiser_html_editors = 1 OR template.load_always = 1)
-AND template.template_type IN (2, 3)
+AND template.template_type IN ({(int)TemplateTypes.Css}, {(int)TemplateTypes.Scss})
 AND otherVersion.id IS NULL
 ORDER BY template.ordering ASC");
 
@@ -1550,6 +1554,9 @@ LIMIT 1";
                         break;
                     }
                 }
+
+                // Create a new version of the template, so that any changes made after this will be done in the new version instead of the published one.
+                await CreateNewVersionAsync(template.TemplateId, version);
             }
 
             var newPublished = PublishedEnvironmentHelper.CalculateEnvironmentsToPublish(currentPublished, version, environment);
@@ -1560,7 +1567,7 @@ LIMIT 1";
         }
 
         /// <inheritdoc />
-        public async Task<ServiceResult<bool>> SaveTemplateVersionAsync(ClaimsIdentity identity, TemplateSettingsModel template, bool skipCompilation = false)
+        public async Task<ServiceResult<bool>> SaveAsync(ClaimsIdentity identity, TemplateSettingsModel template, bool skipCompilation = false)
         {
             if (template == null)
             {
@@ -1684,10 +1691,26 @@ LIMIT 1";
             var templates = await templateDataService.GetScssTemplatesThatAreNotIncludesAsync(template.TemplateId);
             foreach (var otherTemplate in templates)
             {
-                await SaveTemplateVersionAsync(identity, otherTemplate);
+                await SaveAsync(identity, otherTemplate);
             }
 
             return new ServiceResult<bool>(true);
+        }
+
+        /// <inheritdoc />
+        public async Task<ServiceResult<int>> CreateNewVersionAsync(int templateId, int versionBeingDeployed = 0)
+        {
+            // ReSharper disable once InvertIf
+            if (versionBeingDeployed > 0)
+            {
+                var latestVersion = await templateDataService.GetLatestVersionAsync(templateId);
+                if (versionBeingDeployed != latestVersion.Version)
+                {
+                    return new ServiceResult<int>(0);
+                }
+            }
+
+            return new ServiceResult<int>(await templateDataService.CreateNewVersionAsync(templateId));
         }
 
         /// <inheritdoc />
@@ -1708,6 +1731,10 @@ LIMIT 1";
 
             // Make sure the ordering is correct.
             await templateDataService.FixTreeViewOrderingAsync(parentId);
+
+            // Do any table updates that might be needed.
+            await templateDataService.KeepTablesUpToDateAsync();
+            await dynamicContentDataService.KeepTablesUpToDateAsync();
 
             // Get templates in correct order.
             var rawSection = await templateDataService.GetTreeViewSectionAsync(parentId);
@@ -1841,7 +1868,7 @@ LIMIT 1";
 
             if (templateDataResponse.ModelObject.Type is not (TemplateTypes.View or TemplateTypes.Routine or TemplateTypes.Trigger))
             {
-                return await SaveTemplateVersionAsync(identity, templateDataResponse.ModelObject);
+                return await SaveAsync(identity, templateDataResponse.ModelObject);
             }
 
             // Also rename the view, routine, or trigger that this template is managing.
@@ -1858,7 +1885,7 @@ LIMIT 1";
                     break;
             }
 
-            return await SaveTemplateVersionAsync(identity, templateDataResponse.ModelObject);
+            return await SaveAsync(identity, templateDataResponse.ModelObject);
         }
 
         /// <inheritdoc />
@@ -2245,7 +2272,7 @@ LIMIT 1";
                 SELECT template.template_name
                 FROM {WiserTableNames.WiserTemplate} AS template
                 JOIN (SELECT template_id, MAX(version) AS maxVersion FROM {WiserTableNames.WiserTemplate} GROUP BY template_id) AS maxVersion ON template.template_id = maxVersion.template_id AND template.version = maxVersion.maxVersion
-                WHERE template.template_type = 1 AND template.removed = 0 AND template.`{fieldName}` = 1 AND template.template_id <> ?templateId {regexWherePart}
+                WHERE template.template_type = {(int)TemplateTypes.Html} AND template.removed = 0 AND template.`{fieldName}` = 1 AND template.template_id <> ?templateId {regexWherePart}
                 GROUP BY template.template_id
                 LIMIT 1";
 

--- a/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
+++ b/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
@@ -1,7 +1,8 @@
-﻿import { TrackJS } from "trackjs";
-import { Wiser, Misc } from "../../Base/Scripts/Utils.js";
+﻿import {TrackJS} from "trackjs";
+import {Misc, Wiser} from "../../Base/Scripts/Utils.js";
 import "../../Base/Scripts/Processing.js";
-import { Preview } from "./Preview.js";
+import {Preview} from "./Preview.js";
+import "../css/DynamicContent.css";
 
 require("@progress/kendo-ui/js/kendo.notification.js");
 require("@progress/kendo-ui/js/kendo.button.js");
@@ -16,8 +17,6 @@ require("@progress/kendo-ui/js/kendo.multiselect.js");
 require("@progress/kendo-ui/js/kendo.notification.js");
 require("@progress/kendo-ui/js/cultures/kendo.culture.nl-NL.js");
 require("@progress/kendo-ui/js/messages/kendo.messages.nl-NL.js");
-
-import "../css/DynamicContent.css";
 
 // Any custom settings can be added here. They will overwrite most default settings inside the module.
 const moduleSettings = {
@@ -119,7 +118,7 @@ const moduleSettings = {
             if (!this.settings.wiserApiRoot.endsWith("/")) {
                 this.settings.wiserApiRoot += "/";
             }
-            
+
             this.stickyHeader();
 
             this.initializeKendoComponents();
@@ -165,7 +164,7 @@ const moduleSettings = {
                 lastScrollTop = elem.scrollTop <= 0 ? 0 : elem.scrollTop;
             }
         }
-        
+
         /**
          * Initializes all kendo components for the base class.
          */
@@ -219,7 +218,7 @@ const moduleSettings = {
                     spin: () => this.onInputChange(false)
                 });
             });
-            
+
             //MULTISELECT
             container.find(".multi-select").kendoMultiSelect({
                 autoClose: false,
@@ -229,7 +228,7 @@ const moduleSettings = {
             container.find(".select").kendoDropDownList({
                 change: () => this.onInputChange(true)
             });
-            
+
             container.find(".add-subgroup-button").off("click").click(this.onAddSubGroupButtonClick.bind(this));
             container.find(".remove-subgroup-button").off("click").click(this.onRemoveSubGroupButtonClick.bind(this));
 
@@ -312,7 +311,7 @@ const moduleSettings = {
         }
 
         /**
-         * On opening the dynamic content and switching between component modes this method will check which groups and properties should be visible. 
+         * On opening the dynamic content and switching between component modes this method will check which groups and properties should be visible.
          * @param {number} componentModeKey The key value of the componentMode. This key will be used to retrieve the associated value.
          */
         updateComponentModeVisibility(componentModeKey) {
@@ -437,20 +436,20 @@ const moduleSettings = {
 
                     window.popupNotification.show(`Dynamisch component '${document.querySelector('input[name="visibleDescription"]').value}' is succesvol opgeslagen.`, "info");
 
-                
+
                 if (alsoDeployToTest) {
-                    const version = (parseInt($(".historyContainer .historyLine:first").data("historyVersion")) || 0) + 1;
-    
+                    const version = (parseInt($(".historyContainer .historyLine:first").data("historyVersion")) || 1);
+
                     await Wiser.api({
                         url: `${this.settings.wiserApiRoot}dynamic-content/${contentId}/publish/test/${version}`,
                         dataType: "json",
                         type: "POST",
                         contentType: "application/json"
                     });
-    
+
                     window.popupNotification.show(`Dynamisch component is succesvol naar de test-omgeving gezet`, "info");
                 }
-                
+
                 await this.loadComponentHistory();
             } catch (exception) {
                 console.error(exception);
@@ -486,7 +485,7 @@ const moduleSettings = {
         getNewSettings(fields = null) {
             const settingsList = {};
             fields = fields || $("[data-property]").not(".sub-groups [data-property]");
-            
+
             fields.each((index, element) => {
                 const field = $(element);
                 const propertyName = field.data("property");
@@ -508,7 +507,7 @@ const moduleSettings = {
 
                 if (kendoControlName) {
                     const kendoControl = field.data(kendoControlName);
-                    
+
                     if (kendoControl) {
                         settingsListToUse[propertyName] = kendoControl.value();
                         return;
@@ -581,7 +580,7 @@ const moduleSettings = {
                 method: "GET",
                 url: "/Modules/Templates/PreviewTab"
             });
-            
+
             document.getElementById("previewTab").innerHTML = response;
 
             this.preview.initPreviewProfileInputs(true, true);
@@ -735,14 +734,14 @@ const moduleSettings = {
             cloneFieldSet.data("key", `id${newIndex-1}`);
             cloneFieldSet.find("legend .index").html(newIndex-1);
             subGroupsContainer.append(cloneFieldSet);
-            
+
             this.initializeDynamicKendoComponents(cloneFieldSet);
             this.transformCodeMirrorViews(cloneFieldSet);
         }
 
         async onRemoveSubGroupButtonClick(event) {
             event.preventDefault();
-            
+
             const buttonElement = $(event.currentTarget);
             const container = buttonElement.closest(".sub-group");
             if (container.data("key") === "_template") {

--- a/FrontEnd/Modules/Templates/Scripts/Templates.js
+++ b/FrontEnd/Modules/Templates/Scripts/Templates.js
@@ -1812,42 +1812,47 @@ const moduleSettings = {
 
         //Deploy a version to an enviorenment
         async deployEnvironment(environment, templateId, version) {
-            version = version || document.querySelector(`#published-environments .version-${environment} select.combo-select`).value;
-            if (!version) {
-                kendo.alert("U heeft geen geldige versie geselecteerd.");
-                return;
-            }
+            try {
+                version = parseInt(version || document.querySelector(`#published-environments .version-${environment} select.combo-select`).value);
+                if (!version) {
+                    kendo.alert("U heeft geen geldige versie geselecteerd.");
+                    return;
+                }
 
-            let environmentEnum;
-            switch (environment) {
-                case "test":
-                    environmentEnum = 2;
-                    break;
-                case "accept":
-                    environmentEnum = 4;
-                    break;
-                case "live":
-                    environmentEnum = 8;
-                    break;
-                default:
-                    environmentEnum = 1;
-                    break;
-            }
+                let environmentEnum;
+                switch (environment) {
+                    case "test":
+                        environmentEnum = 2;
+                        break;
+                    case "accept":
+                        environmentEnum = 4;
+                        break;
+                    case "live":
+                        environmentEnum = 8;
+                        break;
+                    default:
+                        environmentEnum = 1;
+                        break;
+                }
 
-            await Wiser.api({
-                url: `${this.settings.wiserApiRoot}templates/${templateId}/publish/${environmentEnum}/${version}`,
-                dataType: "json",
-                type: "POST",
-                contentType: "application/json"
-            });
+                await Wiser.api({
+                    url: `${this.settings.wiserApiRoot}templates/${templateId}/publish/${environmentEnum}/${version}`,
+                    dataType: "json",
+                    type: "POST",
+                    contentType: "application/json"
+                });
 
-            // No message needs to be shown if deployed to the development environment because this is default.
-            if (environmentEnum !== 1) {
-                window.popupNotification.show(`Template is succesvol naar de ${environment} omgeving gezet`, "info");
+                // No message needs to be shown if deployed to the development environment because this is default.
+                if (environmentEnum !== 1) {
+                    window.popupNotification.show(`Template is succesvol naar de ${environment} omgeving gezet`, "info");
+                }
+                this.historyLoaded = false;
+                this.measurementsLoaded = false;
+                await this.reloadMetaData(templateId);
+            } catch (exception) {
+                console.error(exception);
+                kendo.alert(`Er is een fout opgetreden bij het deployen van de template: ${exception.responseText || exception}`);
             }
-            this.historyLoaded = false;
-            this.measurementsLoaded = false;
-            await this.reloadMetaData(templateId);
         }
 
         async deployDynamicContentEnvironment(environment, contentId, version) {

--- a/FrontEnd/Modules/Templates/Views/DynamicContent/Partials/PublishedEnvironments.cshtml
+++ b/FrontEnd/Modules/Templates/Views/DynamicContent/Partials/PublishedEnvironments.cshtml
@@ -8,7 +8,8 @@
     <div class="formview full">
         <div class="item version-live">
             <div class="flex-container">
-                <select class="combo-select" placeholder="Maak uw keuze...">
+                <select class="combo-select">
+                    <option value="0">Geen</option>
                     @foreach (var version in versionList)
                     {
                         <!option value="@version" @(version == Model.Versions.LiveVersion ? "selected" : "")>@version</!option>
@@ -21,7 +22,8 @@
 
         <div class="item version-accept">
             <div class="flex-container">
-                <select class="combo-select" placeholder="Maak uw keuze...">
+                <select class="combo-select">
+                    <option value="0">Geen</option>
                     @foreach (var version in versionList)
                     {
                         <!option value="@version" @(version == Model.Versions.AcceptVersion ? "selected" : "")>@version</!option>
@@ -34,7 +36,8 @@
 
         <div class="item version-test">
             <div class="flex-container">
-                <select class="combo-select" placeholder="Maak uw keuze...">
+                <select class="combo-select">
+                    <option value="0">Geen</option>
                     @foreach (var version in versionList)
                     {
                         <!option value="@version" @(version == Model.Versions.TestVersion ? "selected" : "")>@version</!option>
@@ -45,7 +48,7 @@
             </div>
         </div>
     </div>
-        
+
     <div class="formview full">
         <div class="item component-branch-container">
             <div class="flex-container">

--- a/FrontEnd/Modules/Templates/Views/Templates/Partials/PublishedEnvironments.cshtml
+++ b/FrontEnd/Modules/Templates/Views/Templates/Partials/PublishedEnvironments.cshtml
@@ -9,6 +9,7 @@
         <div class="item version-live">
             <div class="flex-container">
                 <select class="combo-select">
+                    <option value="0">Geen</option>
                     @foreach (var version in versionList)
                     {
                         <!option value="@version" @(version == Model.PublishedEnvironments.LiveVersion ? "selected" : "")>@version</!option>
@@ -22,6 +23,7 @@
         <div class="item version-accept">
             <div class="flex-container">
                 <select class="combo-select">
+                    <option value="0">Geen</option>
                     @foreach (var version in versionList)
                     {
                         <!option value="@version" @(version == Model.PublishedEnvironments.AcceptVersion ? "selected" : "")>@version</!option>
@@ -35,6 +37,7 @@
         <div class="item version-test">
             <div class="flex-container">
                 <select class="combo-select">
+                    <option value="0">Geen</option>
                     @foreach (var version in versionList)
                     {
                         <!option value="@version" @(version == Model.PublishedEnvironments.TestVersion ? "selected" : "")>@version</!option>

--- a/FrontEnd/Modules/VersionControl/Scripts/VersionControl.js
+++ b/FrontEnd/Modules/VersionControl/Scripts/VersionControl.js
@@ -1,5 +1,5 @@
-import { TrackJS } from "trackjs";
-import { Wiser } from "../../Base/Scripts/Utils";
+import {TrackJS} from "trackjs";
+import {Wiser} from "../../Base/Scripts/Utils";
 import "../../Base/Scripts/Processing.js";
 import "../Css/VersionControl.css"
 
@@ -161,7 +161,8 @@ const moduleSettings = {
 
             // Tab strip.
             this.mainTabStrip = $("#tabstrip").kendoTabStrip({
-                activate: this.onMainTabStripActivate.bind(this)
+                activate: this.onMainTabStripActivate.bind(this),
+                animation: false
             }).data("kendoTabStrip");
 
             // Commit button


### PR DESCRIPTION

From now on, we will no longer create a new version for every update. When you save a template or component, it will now overwrite the latest version (as long as it's not published to live). When committing a template or component, that will automatically create a new version to work in from then on.

Asana ticket: https://app.asana.com/0/1201027711166952/1204878810711516