### PR TITLE
Use writing connection when getting latest version number.

### DIFF
--- a/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
+++ b/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
@@ -244,7 +244,7 @@ LEFT JOIN {databaseNamePrefix}{WiserTableNames.WiserTemplate} AS otherVersion ON
 WHERE template.template_id = ?templateId
 AND otherVersion.id IS NULL";
             clientDatabaseConnection.AddParameter("templateId", templateId);
-            var dataTable = await clientDatabaseConnection.GetAsync(query);
+            var dataTable = await clientDatabaseConnection.GetAsync(query,  skipCache: true, useWritingConnectionIfAvailable: true);
             if (dataTable.Rows.Count == 0)
             {
                 throw new Exception($"Template with ID {templateId} not found.");


### PR DESCRIPTION
The reading connection was used. If a new version was added in a transaction this function would return the old version.

This went wrong when committing a template directly to live a new version was created for live and then again. Now the writing connection is used the transaction is recognized when getting the latest version.

https://app.asana.com/0/1205090868730163/1205158165975146