### PR TITLE
Fix closing bracket being shown in link-item

### DIFF
--- a/Api/Modules/Items/FieldTemplates/linked-item.js
+++ b/Api/Modules/Items/FieldTemplates/linked-item.js
@@ -36,7 +36,7 @@ Wiser.api({ url: url }).then(function(results) {
 
         if (result.hasOwnProperty("details")) {
             result.details.forEach((detail) => {
-                const regExp = new RegExp(`\{${regExpEscape(detail.key)}`, "gi");
+                const regExp = new RegExp(`\{${regExpEscape(detail.key)}\}`, "gi");
                 newValue = newValue.replace(regExp, detail.value);
             });
         }


### PR DESCRIPTION
https://app.asana.com/0/1144661858028300/1204655574479297/f

Fixes a bug causing the closing bracket of replacements to show in wiser properties of type linked item

For example the template `{orderId} - {title}` would be replaced as `123} - awesome product}` instead of `123 - awesome product`