### PR TITLE
Functionality for loading GCL/Wiser plugins

### DIFF
--- a/Api/Core/Helpers/TypeHelpers.cs
+++ b/Api/Core/Helpers/TypeHelpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
+using Microsoft.AspNetCore.Hosting;
 
 namespace Api.Core.Helpers
 {
@@ -29,8 +30,19 @@ namespace Api.Core.Helpers
         /// we will need to extend this function with some security checks and load the plugins in isolated contexts.
         /// </remarks>
         /// <param name="pluginsDirectory">The directory that contains the plugins.</param>
-        public static void LoadPlugins(string pluginsDirectory)
+        /// <param name="webHostEnvironment">The IWebHostEnvironment to access the Content Root Path.</param>
+        public static void LoadPlugins(string pluginsDirectory, IWebHostEnvironment webHostEnvironment)
         {
+            if (String.IsNullOrWhiteSpace(pluginsDirectory))
+            {
+                return;
+            }
+
+            if (!Path.IsPathRooted(pluginsDirectory))
+            {
+                pluginsDirectory = Path.Combine(webHostEnvironment.ContentRootPath, pluginsDirectory);
+            }
+
             if (!Directory.Exists(pluginsDirectory))
             {
                 // Handle the case when the Plugins directory does not exist

--- a/Api/Core/Helpers/TypeHelpers.cs
+++ b/Api/Core/Helpers/TypeHelpers.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.IO;
-using System.Reflection;
-using Microsoft.AspNetCore.Hosting;
 
 namespace Api.Core.Helpers
 {
@@ -17,52 +14,6 @@ namespace Api.Core.Helpers
         public static bool IsNumericType(Type type)
         {
             return CheckIsNumericType(Nullable.GetUnderlyingType(type)) || CheckIsNumericType(type);
-        }
-
-        /// <summary>
-        /// Load plugins for Wiser. This will load all DLL files in the given directory.
-        /// This method should be called during the startup of the application, before registering the services.
-        /// </summary>
-        /// <remarks>
-        /// This function does not do any checks on the DLL files. It will try to load all DLL files in the given directory.
-        /// This is meant for plugins that are developed by Wiser developers, so we know they are safe to load.
-        /// If we want to be able to load external plugins in the future,
-        /// we will need to extend this function with some security checks and load the plugins in isolated contexts.
-        /// </remarks>
-        /// <param name="pluginsDirectory">The directory that contains the plugins.</param>
-        /// <param name="webHostEnvironment">The IWebHostEnvironment to access the Content Root Path.</param>
-        public static void LoadPlugins(string pluginsDirectory, IWebHostEnvironment webHostEnvironment)
-        {
-            if (String.IsNullOrWhiteSpace(pluginsDirectory))
-            {
-                return;
-            }
-
-            if (!Path.IsPathRooted(pluginsDirectory))
-            {
-                pluginsDirectory = Path.Combine(webHostEnvironment.ContentRootPath, pluginsDirectory);
-            }
-
-            if (!Directory.Exists(pluginsDirectory))
-            {
-                // Handle the case when the Plugins directory does not exist
-                return;
-            }
-
-            var dllFiles = Directory.GetFiles(pluginsDirectory, "*.dll");
-
-            foreach (var dllFile in dllFiles)
-            {
-                try
-                {
-                    Assembly.LoadFrom(dllFile);
-                }
-                catch (Exception ex)
-                {
-                    // Handle assembly loading exceptions
-                    Console.WriteLine($"Error loading plugin assembly: {ex}");
-                }
-            }
         }
 
         private static bool CheckIsNumericType(Type type)

--- a/Api/Core/Helpers/TypeHelpers.cs
+++ b/Api/Core/Helpers/TypeHelpers.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.Reflection;
 
 namespace Api.Core.Helpers
 {
@@ -14,6 +16,41 @@ namespace Api.Core.Helpers
         public static bool IsNumericType(Type type)
         {
             return CheckIsNumericType(Nullable.GetUnderlyingType(type)) || CheckIsNumericType(type);
+        }
+
+        /// <summary>
+        /// Load plugins for Wiser. This will load all DLL files in the given directory.
+        /// This method should be called during the startup of the application, before registering the services.
+        /// </summary>
+        /// <remarks>
+        /// This function does not do any checks on the DLL files. It will try to load all DLL files in the given directory.
+        /// This is meant for plugins that are developed by Wiser developers, so we know they are safe to load.
+        /// If we want to be able to load external plugins in the future,
+        /// we will need to extend this function with some security checks and load the plugins in isolated contexts.
+        /// </remarks>
+        /// <param name="pluginsDirectory">The directory that contains the plugins.</param>
+        public static void LoadPlugins(string pluginsDirectory)
+        {
+            if (!Directory.Exists(pluginsDirectory))
+            {
+                // Handle the case when the Plugins directory does not exist
+                return;
+            }
+
+            var dllFiles = Directory.GetFiles(pluginsDirectory, "*.dll");
+
+            foreach (var dllFile in dllFiles)
+            {
+                try
+                {
+                    Assembly.LoadFrom(dllFile);
+                }
+                catch (Exception ex)
+                {
+                    // Handle assembly loading exceptions
+                    Console.WriteLine($"Error loading plugin assembly: {ex}");
+                }
+            }
         }
 
         private static bool CheckIsNumericType(Type type)

--- a/Api/Core/Interfaces/IPluginsService.cs
+++ b/Api/Core/Interfaces/IPluginsService.cs
@@ -1,0 +1,20 @@
+﻿namespace Api.Core.Interfaces;
+
+/// <summary>
+/// A service for loading plugins and maybe other things in the future.
+/// </summary>
+public interface IPluginsService
+{
+    /// <summary>
+    /// Load plugins for Wiser. This will load all DLL files in the given directory.
+    /// This method should be called during the startup of the application, before registering the services.
+    /// </summary>
+    /// <remarks>
+    /// This function does not do any checks on the DLL files. It will try to load all DLL files in the given directory.
+    /// This is meant for plugins that are developed by Wiser developers, so we know they are safe to load.
+    /// If we want to be able to load external plugins in the future,
+    /// we will need to extend this function with some security checks and load the plugins in isolated contexts.
+    /// </remarks>
+    /// <param name="pluginsDirectory">The directory that contains the plugins.</param>
+    void LoadPlugins(string pluginsDirectory);
+}

--- a/Api/Core/Models/ApiSettings.cs
+++ b/Api/Core/Models/ApiSettings.cs
@@ -45,7 +45,7 @@ namespace Api.Core.Models
         public string PusherAppId { get; set; }
 
         /// <summary>
-        /// The app key used for the Pusher server. 
+        /// The app key used for the Pusher server.
         /// </summary>
         public string PusherAppKey { get; set; }
 
@@ -74,5 +74,10 @@ namespace Api.Core.Models
         /// Gets or sets whether the NPM package 'terser' should be used when minifying scripts saved in the templates module.
         /// </summary>
         public bool UseTerserForTemplateScriptMinification { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directory where the plugins are located.
+        /// </summary>
+        public string PluginsDirectory { get; set; }
     }
 }

--- a/Api/Core/Services/PluginsService.cs
+++ b/Api/Core/Services/PluginsService.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using Api.Core.Interfaces;
+using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Core.Services;
+
+/// <inheritdoc cref="IPluginsService" />
+public class PluginsService : IPluginsService, ITransientService
+{
+    private readonly IWebHostEnvironment webHostEnvironment;
+    private readonly ILogger logger;
+
+    /// <summary>
+    /// Creates a new instance of PluginsService.
+    /// </summary>
+    public PluginsService(IWebHostEnvironment webHostEnvironment, ILogger<PluginsService> logger)
+    {
+        this.webHostEnvironment = webHostEnvironment;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc />
+    public void LoadPlugins(string pluginsDirectory)
+    {
+        if (String.IsNullOrWhiteSpace(pluginsDirectory))
+        {
+            // Empty plugins directory, so no plugins to load.
+            return;
+        }
+
+        if (!Path.IsPathRooted(pluginsDirectory))
+        {
+            pluginsDirectory = Path.Combine(webHostEnvironment.ContentRootPath, pluginsDirectory);
+        }
+
+        if (!Directory.Exists(pluginsDirectory))
+        {
+            // Plugins directory doesn't exist, so no plugins to load.
+            return;
+        }
+
+        var dllFiles = Directory.GetFiles(pluginsDirectory, "*.dll");
+
+        foreach (var dllFile in dllFiles)
+        {
+            try
+            {
+                Assembly.LoadFrom(dllFile);
+            }
+            catch (Exception exception)
+            {
+                // Handle assembly loading exceptions
+                logger.LogError(exception, $"Failed to load plugin {dllFile}");
+            }
+        }
+    }
+}

--- a/Api/Startup.cs
+++ b/Api/Startup.cs
@@ -338,6 +338,34 @@ namespace Api
                     Predicate = _ => true
                 });
             });
+
+            LoadPlugins();
+        }
+
+        public void LoadPlugins()
+        {
+            var pluginsDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Plugins");
+
+            if (!Directory.Exists(pluginsDirectory))
+            {
+                // Handle the case when the Plugins directory does not exist
+                return;
+            }
+
+            var dllFiles = Directory.GetFiles(pluginsDirectory, "*.dll");
+
+            foreach (var dllFile in dllFiles)
+            {
+                try
+                {
+                    Assembly.LoadFrom(dllFile);
+                }
+                catch (Exception ex)
+                {
+                    // Handle assembly loading exceptions
+                    Console.WriteLine($"Error loading plugin assembly: {ex}");
+                }
+            }
         }
     }
 #pragma warning restore CS1591

--- a/Api/Startup.cs
+++ b/Api/Startup.cs
@@ -155,7 +155,7 @@ namespace Api
             });
 
             // Load plugins for GCL and Wiser.
-            TypeHelpers.LoadPlugins(Configuration.GetValue<string>("Api:PluginsDirectory"));
+            TypeHelpers.LoadPlugins(Configuration.GetValue<string>("Api:PluginsDirectory"), webHostEnvironment);
 
             // Services from GCL. Some services are registered because they are required by other GCL services, not because this API uses them.
             services.AddGclServices(Configuration, false, true);

--- a/Api/Startup.cs
+++ b/Api/Startup.cs
@@ -154,6 +154,7 @@ namespace Api
             });
 
             // Services from GCL. Some services are registered because they are required by other GCL services, not because this API uses them.
+            LoadPlugins();
             services.AddGclServices(Configuration, false, true);
             services.Decorate<IDatabaseHelpersService, CachedDatabaseHelpersService>();
 
@@ -338,13 +339,11 @@ namespace Api
                     Predicate = _ => true
                 });
             });
-
-            LoadPlugins();
         }
 
         public void LoadPlugins()
         {
-            var pluginsDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Plugins");
+            var pluginsDirectory = Configuration.GetValue<string>("Api:PluginsDirectory");
 
             if (!Directory.Exists(pluginsDirectory))
             {

--- a/Api/Startup.cs
+++ b/Api/Startup.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using Api.Core.Filters;
-using Api.Core.Helpers;
+using Api.Core.Interfaces;
 using Api.Core.Models;
 using Api.Core.Services;
 using Api.Modules.Customers.Interfaces;
@@ -154,9 +154,6 @@ namespace Api
                 }
             });
 
-            // Load plugins for GCL and Wiser.
-            TypeHelpers.LoadPlugins(Configuration.GetValue<string>("Api:PluginsDirectory"), webHostEnvironment);
-
             // Services from GCL. Some services are registered because they are required by other GCL services, not because this API uses them.
             services.AddGclServices(Configuration, false, true);
             services.Decorate<IDatabaseHelpersService, CachedDatabaseHelpersService>();
@@ -281,7 +278,7 @@ namespace Api
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
         }
 
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger, IPluginsService pluginService)
         {
             if (env.IsDevelopment())
             {
@@ -342,6 +339,9 @@ namespace Api
                     Predicate = _ => true
                 });
             });
+
+            // Load plugins for GCL and Wiser.
+            pluginService.LoadPlugins(Configuration.GetValue<string>("Api:PluginsDirectory"));
         }
     }
 #pragma warning restore CS1591

--- a/Api/Startup.cs
+++ b/Api/Startup.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using Api.Core.Filters;
+using Api.Core.Helpers;
 using Api.Core.Models;
 using Api.Core.Services;
 using Api.Modules.Customers.Interfaces;
@@ -153,8 +154,10 @@ namespace Api
                 }
             });
 
+            // Load plugins for GCL and Wiser.
+            TypeHelpers.LoadPlugins(Configuration.GetValue<string>("Api:PluginsDirectory"));
+
             // Services from GCL. Some services are registered because they are required by other GCL services, not because this API uses them.
-            LoadPlugins();
             services.AddGclServices(Configuration, false, true);
             services.Decorate<IDatabaseHelpersService, CachedDatabaseHelpersService>();
 
@@ -339,32 +342,6 @@ namespace Api
                     Predicate = _ => true
                 });
             });
-        }
-
-        public void LoadPlugins()
-        {
-            var pluginsDirectory = Configuration.GetValue<string>("Api:PluginsDirectory");
-
-            if (!Directory.Exists(pluginsDirectory))
-            {
-                // Handle the case when the Plugins directory does not exist
-                return;
-            }
-
-            var dllFiles = Directory.GetFiles(pluginsDirectory, "*.dll");
-
-            foreach (var dllFile in dllFiles)
-            {
-                try
-                {
-                    Assembly.LoadFrom(dllFile);
-                }
-                catch (Exception ex)
-                {
-                    // Handle assembly loading exceptions
-                    Console.WriteLine($"Error loading plugin assembly: {ex}");
-                }
-            }
         }
     }
 #pragma warning restore CS1591

--- a/Api/appsettings.Development.json
+++ b/Api/appsettings.Development.json
@@ -15,6 +15,6 @@
   "API": {
     "BaseUrl": "https://localhost:44349",
     "DefaultUsersCacheDuration": "00:00:05",
-    "PluginsDirectory": "C:\\Ontwikkeling\\Intern\\Wiser 3\\Api\\Plugins"
+    "PluginsDirectory": "Plugins"
   }
 }

--- a/Api/appsettings.Development.json
+++ b/Api/appsettings.Development.json
@@ -14,6 +14,7 @@
   },
   "API": {
     "BaseUrl": "https://localhost:44349",
-    "DefaultUsersCacheDuration": "00:00:05"
+    "DefaultUsersCacheDuration": "00:00:05",
+    "PluginsDirectory": "C:\\Ontwikkeling\\Intern\\Wiser 3\\Api\\Plugins"
   }
 }

--- a/FrontEnd/Core/Models/FrontEndSettings.cs
+++ b/FrontEnd/Core/Models/FrontEndSettings.cs
@@ -63,5 +63,10 @@ namespace FrontEnd.Core.Models
         /// This value is not used when not using multi tenancy.
         /// </summary>
         public string MainSubDomain { get; set; } = "main";
+
+        /// <summary>
+        /// Gets or sets the directory where the plugins are located.
+        /// </summary>
+        public string PluginsDirectory { get; set; }
     }
 }

--- a/FrontEnd/Modules/Templates/Controllers/DynamicContentController.cs
+++ b/FrontEnd/Modules/Templates/Controllers/DynamicContentController.cs
@@ -114,9 +114,9 @@ namespace FrontEnd.Modules.Templates.Controllers
         }
 
         /// <summary>
-        /// Get all possible components. These components should are retrieved from the assembly and should have the basetype CmsComponent&lt;CmsSettings, Enum&gt;
+        /// Get all possible components. These components should are retrieved from the assembly and any plugins and should have the base type CmsComponent&lt;CmsSettings, Enum&gt;
         /// </summary>
-        /// <returns>Dictionary of typeinfos and object attributes of all the components found in the GCL.</returns>
+        /// <returns>Dictionary of type infos and object attributes of all the components found in the GCL.</returns>
         private Dictionary<TypeInfo, CmsObjectAttribute> GetComponents()
         {
             var componentType = typeof(CmsComponent<CmsSettings, Enum>);
@@ -125,8 +125,7 @@ namespace FrontEnd.Modules.Templates.Controllers
             foreach (var assembly in loadedAssemblies)
             {
                 var typeInfoList = assembly.DefinedTypes.Where(
-                    type => type.BaseType != null
-                            && type.BaseType.IsGenericType
+                    type => type.BaseType is {IsGenericType: true}
                             && componentType.IsGenericType
                             && type.BaseType.GetGenericTypeDefinition() == componentType.GetGenericTypeDefinition()
                 ).OrderBy(type => type.Name).ToList();
@@ -137,22 +136,6 @@ namespace FrontEnd.Modules.Templates.Controllers
                 }
             }
 
-            /*var componentType = typeof(CmsComponent<CmsSettings, Enum>);
-            var assembly = componentType.Assembly;
-
-            var typeInfoList = assembly.DefinedTypes.Where(
-                type => type.BaseType != null
-                        && type.BaseType.IsGenericType
-                        && componentType.IsGenericType
-                        && type.BaseType.GetGenericTypeDefinition() == componentType.GetGenericTypeDefinition()
-            ).OrderBy(type => type.Name).ToList();
-
-            var resultDictionary = new Dictionary<TypeInfo, CmsObjectAttribute>();
-
-            foreach (var typeInfo in typeInfoList)
-            {
-                resultDictionary.Add(typeInfo, typeInfo.GetCustomAttribute<CmsObjectAttribute>());
-            }*/
             return resultDictionary;
         }
     }

--- a/FrontEnd/Modules/Templates/Controllers/DynamicContentController.cs
+++ b/FrontEnd/Modules/Templates/Controllers/DynamicContentController.cs
@@ -62,7 +62,7 @@ namespace FrontEnd.Modules.Templates.Controllers
         public IActionResult History([FromBody]List<HistoryVersionModel> viewData)
         {
             var viewModel = new DynamicContentHistoryPaneViewModel { History = new List<HistoryVersionViewModel>() };
-            
+
             foreach (var history in viewData)
             {
                 viewModel.History.Add(new HistoryVersionViewModel
@@ -81,12 +81,12 @@ namespace FrontEnd.Modules.Templates.Controllers
             // ReSharper disable once Mvc.PartialViewNotResolved
             return PartialView("Partials/DynamicContentHistoryPane", viewModel);
         }
-        
+
         [HttpPost, Route("HistoryRow")]
         public IActionResult HistoryRow([FromBody]List<HistoryVersionModel> viewData)
         {
             var viewModel = new DynamicContentHistoryPaneViewModel { History = new List<HistoryVersionViewModel>() };
-            
+
             foreach (var history in viewData)
             {
                 viewModel.History.Add(new HistoryVersionViewModel
@@ -112,7 +112,7 @@ namespace FrontEnd.Modules.Templates.Controllers
             // ReSharper disable once Mvc.PartialViewNotResolved
             return PartialView("Partials/PublishedEnvironments", tabViewData);
         }
-        
+
         /// <summary>
         /// Get all possible components. These components should are retrieved from the assembly and should have the basetype CmsComponent&lt;CmsSettings, Enum&gt;
         /// </summary>
@@ -120,6 +120,24 @@ namespace FrontEnd.Modules.Templates.Controllers
         private Dictionary<TypeInfo, CmsObjectAttribute> GetComponents()
         {
             var componentType = typeof(CmsComponent<CmsSettings, Enum>);
+            var resultDictionary = new Dictionary<TypeInfo, CmsObjectAttribute>();
+            var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().Where(assembly => assembly.FullName!.StartsWith("GeeksCoreLibrary"));
+            foreach (var assembly in loadedAssemblies)
+            {
+                var typeInfoList = assembly.DefinedTypes.Where(
+                    type => type.BaseType != null
+                            && type.BaseType.IsGenericType
+                            && componentType.IsGenericType
+                            && type.BaseType.GetGenericTypeDefinition() == componentType.GetGenericTypeDefinition()
+                ).OrderBy(type => type.Name).ToList();
+
+                foreach (var typeInfo in typeInfoList)
+                {
+                    resultDictionary.Add(typeInfo, typeInfo.GetCustomAttribute<CmsObjectAttribute>());
+                }
+            }
+
+            /*var componentType = typeof(CmsComponent<CmsSettings, Enum>);
             var assembly = componentType.Assembly;
 
             var typeInfoList = assembly.DefinedTypes.Where(
@@ -134,7 +152,7 @@ namespace FrontEnd.Modules.Templates.Controllers
             foreach (var typeInfo in typeInfoList)
             {
                 resultDictionary.Add(typeInfo, typeInfo.GetCustomAttribute<CmsObjectAttribute>());
-            }
+            }*/
             return resultDictionary;
         }
     }

--- a/FrontEnd/Startup.cs
+++ b/FrontEnd/Startup.cs
@@ -1,3 +1,4 @@
+using Api.Core.Helpers;
 using FrontEnd.Core.Interfaces;
 using FrontEnd.Core.Models;
 using FrontEnd.Core.Services;
@@ -95,6 +96,9 @@ namespace FrontEnd
                 options.SerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Local;
                 options.SerializerSettings.Converters.Add(new StringEnumConverter());
             });
+
+            // Load plugins for GCL and Wiser.
+            TypeHelpers.LoadPlugins(Configuration.GetValue<string>("FrontEnd:PluginsDirectory"));
 
             // Setup dependency injection.
             services.AddHttpContextAccessor();

--- a/FrontEnd/Startup.cs
+++ b/FrontEnd/Startup.cs
@@ -55,9 +55,12 @@ namespace FrontEnd
             Log.Logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(Configuration)
                 .CreateLogger();
+
+            this.webHostEnvironment = webHostEnvironment;
         }
 
         public IConfiguration Configuration { get; }
+        private readonly IWebHostEnvironment webHostEnvironment;
 
         // This method gets called by the runtime. Use this method to add services to the container.
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
@@ -98,7 +101,7 @@ namespace FrontEnd
             });
 
             // Load plugins for GCL and Wiser.
-            TypeHelpers.LoadPlugins(Configuration.GetValue<string>("FrontEnd:PluginsDirectory"));
+            TypeHelpers.LoadPlugins(Configuration.GetValue<string>("FrontEnd:PluginsDirectory"), webHostEnvironment);
 
             // Setup dependency injection.
             services.AddHttpContextAccessor();

--- a/FrontEnd/appsettings.Development.json
+++ b/FrontEnd/appsettings.Development.json
@@ -5,6 +5,6 @@
   },
   "FrontEnd": {
     "ApiBaseUrl": "https://localhost:44349/",
-    "PluginsDirectory": "C:\\Ontwikkeling\\Intern\\Wiser 3\\Api\\Plugins"
+    "PluginsDirectory": "..\\Api\\Plugins"
   }
 }

--- a/FrontEnd/appsettings.Development.json
+++ b/FrontEnd/appsettings.Development.json
@@ -4,6 +4,7 @@
     "SecretsBaseDirectory": "Z:\\AppSettings\\WiserCore\\FrontEnd\\"
   },
   "FrontEnd": {
-    "ApiBaseUrl": "https://localhost:44349/"
+    "ApiBaseUrl": "https://localhost:44349/",
+    "PluginsDirectory": "C:\\Ontwikkeling\\Intern\\Wiser 3\\Api\\Plugins"
   }
 }


### PR DESCRIPTION
We have split the GCL into multiple smaller libraries. For example, the configurator is now a separate library and no longer part of the base GCL library. To still be able to use and config configurators in Wiser, we need to be able to load plugins dynamically.

Asana ticket: https://app.asana.com/0/1205090868730163/1205074310342800