### PR TITLE
Fix default value bug for numeric fields

### DIFF
--- a/FrontEnd/Modules/Admin/Scripts/EntityTab.js
+++ b/FrontEnd/Modules/Admin/Scripts/EntityTab.js
@@ -3613,7 +3613,7 @@ entityProperties.options.saveValueAsItemLink = document.getElementById("saveValu
                 this.numberOfDec.value(getOptionValueAndDeleteForOptionsField("decimals", 0));
                 // set format dropdown
                 let found = false;
-                const format = getOptionValueAndDeleteForOptionsField("format");
+                const format = getOptionValueAndDeleteForOptionsField("format", "");
                 this.numberFormat.select((dataItem) => {
                     if (dataItem.value === format) {
                         return found = true;


### PR DESCRIPTION
https://app.asana.com/0/0/1204841139638518/f

When inputting 0 for the amount of decimals in a numeric input field, the value would jump back to 2 when saving. This fixes that bug.
