### PR TITLE
bugfix/item-linker-showing-wrong-checked-values

### DIFF
--- a/Api/Modules/Items/Controllers/ItemsController.cs
+++ b/Api/Modules/Items/Controllers/ItemsController.cs
@@ -405,13 +405,14 @@ namespace Api.Modules.Items.Controllers
         /// <param name="encryptedItemId">Optional: The encrypted ID of the parent to fix the ordering for. If no value has been given, the root will be used as parent.</param>
         /// <param name="orderBy">Optional: Enter the value "item_title" to order by title, or nothing to order by order number.</param>
         /// <param name="checkId">Optional: This is meant for item-linker fields. This is the encrypted ID for the item that should currently be checked.</param>
+        /// <param name="linkType">Optional: The type number of the link. This is used in combination with "checkId"; So that items will only be marked as checked if they have the given link ID.</param>
         /// <returns>A list of <see cref="TreeViewItemModel"/>.</returns>
         [HttpGet]
         [Route("tree-view")]
         [ProducesResponseType(typeof(List<TreeViewItemModel>), StatusCodes.Status200OK)]
-        public async Task<IActionResult> GetItemsForTreeViewAsync([FromQuery] int moduleId, [FromQuery] string encryptedItemId = null, [FromQuery] string entityType = null, [FromQuery] string orderBy = null, [FromQuery] string checkId = null)
+        public async Task<IActionResult> GetItemsForTreeViewAsync([FromQuery] int moduleId, [FromQuery] string encryptedItemId = null, [FromQuery] string entityType = null, [FromQuery] string orderBy = null, [FromQuery] string checkId = null, [FromQuery] int linkType = 0)
         {
-            return (await itemsService.GetItemsForTreeViewAsync(moduleId, (ClaimsIdentity)User.Identity, entityType, encryptedItemId, orderBy, checkId)).GetHttpResponseMessage();
+            return (await itemsService.GetItemsForTreeViewAsync(moduleId, (ClaimsIdentity)User.Identity, entityType, encryptedItemId, orderBy, checkId, linkType)).GetHttpResponseMessage();
         }
 
         /// <summary>

--- a/Api/Modules/Items/FieldTemplates/item-linker.js
+++ b/Api/Modules/Items/FieldTemplates/item-linker.js
@@ -20,10 +20,10 @@ var stopLoader = function(reloadGridWhenDone) {
     if (loadingCount < 0) {
         loadingCount = 0;
     }
-    
+
     if (loadingCount === 0) {
         loader.removeClass("loading");
-    
+
         if (reloadGridWhenDone) {
             checkGridElement.data("kendoGrid").dataSource.read();
         }
@@ -42,7 +42,7 @@ field.find(".filterText").keyup(function (event) {
                 $(this).show();
             });
         });
-        
+
         checkTreeElement.find(".k-group .k-in:contains(" + filterText + ")").each(function () {
             $(this).parents("ul, li").each(function () {
                 $(this).show();
@@ -71,9 +71,9 @@ checkTreeElement.kendoTreeView({
         if (readonly === true) {
             return;
         }
-        
+
         startLoader();
-        
+
         let sourceItem = event.sender.dataItem(event.node);
         let methodName = sourceItem.checked ? "add-links" : "remove-links";
 
@@ -97,9 +97,9 @@ checkTreeElement.kendoTreeView({
         transport: {
             read: (kendoReadOptions) => {
                 Wiser.api({
-                    url: !showStructure 
-                        ? window.dynamicItems.settings.serviceRoot + "/GET_ALL_ITEMS_OF_TYPE?moduleid=" + options.moduleId + "&checkId=" + encodeURIComponent(currentItemId) + "&entityType=" + encodeURIComponent((!options.entityTypes ? "" : options.entityTypes.join())) + "&orderBy=" + encodeURIComponent((options.orderBy || ""))
-                        : window.dynamicItems.settings.wiserApiRoot + "items/tree-view?moduleId=" + options.moduleId + "&checkId=" + encodeURIComponent(currentItemId) + (!options.entityTypes ? "" : ("&entityType=" + encodeURIComponent(options.entityTypes.join()))) + (options.orderBy ? ("&orderBy=" + encodeURIComponent(options.orderBy)) : ""),
+                    url: !showStructure
+                        ? `${window.dynamicItems.settings.serviceRoot}/GET_ALL_ITEMS_OF_TYPE?moduleid=${options.moduleId}&checkId=${encodeURIComponent(currentItemId)}&entityType=${encodeURIComponent((!options.entityTypes ? "" : options.entityTypes.join()))}&orderBy=${encodeURIComponent((options.orderBy || ""))}&linkType=${options.linkTypeNumber || 0}`
+                        : `${window.dynamicItems.settings.wiserApiRoot}items/tree-view?moduleId=${options.moduleId}&checkId=${encodeURIComponent(currentItemId)}${!options.entityTypes ? "" : ("&entityType=" + encodeURIComponent(options.entityTypes.join()))}${options.orderBy ? ("&orderBy=" + encodeURIComponent(options.orderBy)) : ""}&linkType=${options.linkTypeNumber || 0}`,
                     dataType: "json",
                     method: "GET",
                     data: kendoReadOptions.data
@@ -163,11 +163,11 @@ Wiser.api({
             columns.push(column);
         }
     }
-    
+
     if (!options.hideCommandColumn) {
         let commandColumnWidth = 60;
         var commands = [];
-        
+
         if (!options.disableOpeningOfItems) {
             commands.push({
                 name: "openDetails",
@@ -187,10 +187,10 @@ Wiser.api({
                 });
             }
         }
-        
+
         if (!readonly && options.deletionOfItems && options.deletionOfItems.toLowerCase() !== "off") {
             commandColumnWidth += 60;
-            
+
             commands.push({
                 name: "remove",
                 text: "",
@@ -198,33 +198,33 @@ Wiser.api({
                 click: function(event) { window.dynamicItems.grids.onDeleteItemClick(event, this, options.deletionOfItems, options, false); }
             });
         }
-        
+
         columns.push({
             title: "&nbsp;",
             width: commandColumnWidth,
             command: commands
         });
     }
-    
+
     var toolbar = [];
-     
+
     if (!options.toolbar || !options.toolbar.hideExportButton) {
         toolbar.push({name: "excel"});
     }
-    
+
     if (!readonly && (!options.toolbar || !options.toolbar.hideCheckAllButton)) {
-        toolbar.push({ 
-            name: "checkAll", 
-            text: "Alles selecteren", 
-            template: "<a class='k-button k-button-icontext' href='\\#' onclick='return window.dynamicItems.grids.onItemLinkerSelectAll(\"\\#checkTree_{propertyIdWithSuffix}\", true)'><span class='k-icon k-i-checkbox-checked'></span>Alles selecteren</a>" 
+        toolbar.push({
+            name: "checkAll",
+            text: "Alles selecteren",
+            template: "<a class='k-button k-button-icontext' href='\\#' onclick='return window.dynamicItems.grids.onItemLinkerSelectAll(\"\\#checkTree_{propertyIdWithSuffix}\", true)'><span class='k-icon k-i-checkbox-checked'></span>Alles selecteren</a>"
         });
     }
-    
+
     if (!readonly && (!options.toolbar || !options.toolbar.hideUncheckAllButton)) {
-        toolbar.push({ 
-            name: "uncheckAll", 
-            text: "Alles deselecteren", 
-            template: "<a class='k-button k-button-icontext' href='\\#' onclick='return window.dynamicItems.grids.onItemLinkerSelectAll(\"\\#checkTree_{propertyIdWithSuffix}\", false)'><span class='k-icon k-i-checkbox'></span>Alles deselecteren</a>" 
+        toolbar.push({
+            name: "uncheckAll",
+            text: "Alles deselecteren",
+            template: "<a class='k-button k-button-icontext' href='\\#' onclick='return window.dynamicItems.grids.onItemLinkerSelectAll(\"\\#checkTree_{propertyIdWithSuffix}\", false)'><span class='k-icon k-i-checkbox'></span>Alles deselecteren</a>"
         });
     }
 
@@ -264,14 +264,14 @@ Wiser.api({
                     if (readonly === true) {
                         return;
                     }
-                    
+
                     startLoader();
-                    
+
                     let itemModel = {
                         title: options.data.title,
                         details: []
                     };
-                    
+
                     for (let key in options.data.property_) {
                         itemModel.details.push({
                             key: key,
@@ -299,7 +299,7 @@ Wiser.api({
                     if (readonly === true) {
                         return;
                     }
-                    
+
                     startLoader();
 
                     Wiser.api({

--- a/Api/Modules/Items/Interfaces/IItemsService.cs
+++ b/Api/Modules/Items/Interfaces/IItemsService.cs
@@ -218,8 +218,9 @@ namespace Api.Modules.Items.Interfaces
         /// <param name="encryptedParentId">Optional: The encrypted ID of the parent to fix the ordering for. If no value has been given, the root will be used as parent.</param>
         /// <param name="orderBy">Optional: Enter the value "item_title" to order by title, or nothing to order by order number.</param>
         /// <param name="encryptedCheckId">Optional: This is meant for item-linker fields. This is the encrypted ID for the item that should currently be checked.</param>
+        /// <param name="linkType">Optional: The type number of the link. This is used in combination with "checkId"; So that items will only be marked as checked if they have the given link ID.</param>
         /// <returns>A list of <see cref="TreeViewItemModel"/>.</returns>
-        Task<ServiceResult<List<TreeViewItemModel>>> GetItemsForTreeViewAsync(int moduleId, ClaimsIdentity identity, string entityType = null, string encryptedParentId = null, string orderBy = null, string encryptedCheckId = null);
+        Task<ServiceResult<List<TreeViewItemModel>>> GetItemsForTreeViewAsync(int moduleId, ClaimsIdentity identity, string entityType = null, string encryptedParentId = null, string orderBy = null, string encryptedCheckId = null, int linkType = 0);
 
         /// <summary>
         /// Move an item to a different position in the tree view.

--- a/Api/Modules/Items/Services/ItemsService.cs
+++ b/Api/Modules/Items/Services/ItemsService.cs
@@ -2032,7 +2032,7 @@ SELECT entity_type FROM {tableName}_archive WHERE id = ?itemId";
         }
 
         /// <inheritdoc />
-        public async Task<ServiceResult<List<TreeViewItemModel>>> GetItemsForTreeViewAsync(int moduleId, ClaimsIdentity identity, string entityType = null, string encryptedParentId = null, string orderBy = null, string encryptedCheckId = null)
+        public async Task<ServiceResult<List<TreeViewItemModel>>> GetItemsForTreeViewAsync(int moduleId, ClaimsIdentity identity, string entityType = null, string encryptedParentId = null, string orderBy = null, string encryptedCheckId = null, int linkType = 0)
         {
             if (moduleId <= 0)
             {
@@ -2112,7 +2112,12 @@ SELECT entity_type FROM {tableName}_archive WHERE id = ?itemId";
             if (checkId > 0)
             {
                 checkIdJoin = $@"# Check if item needs to be checked in item-linker field.
-                                    LEFT JOIN {WiserTableNames.WiserItemLink} AS checked ON checked.item_id = item.id AND checked.destination_item_id = ?checkId";
+LEFT JOIN {WiserTableNames.WiserItemLink} AS checked ON checked.item_id = item.id AND checked.destination_item_id = ?checkId";
+                if (linkType > 0)
+                {
+                    clientDatabaseConnection.AddParameter("linkType", linkType);
+                    checkIdJoin += " AND checked.type = ?linkType";
+                }
             }
 
             // Get items via wiser_itemlink.


### PR DESCRIPTION
DynamicItems - Item-linker - Fixed problem that item-linker fields would show values as checked when they shouldn't be. This happened when you use the same entity types with multiple different link types. 

Asana ticket: https://app.asana.com/0/1151477971646641/1201976797412107