### PR TITLE
Update WiserQueryTab.js

### DIFF
--- a/FrontEnd/Modules/Admin/Scripts/WiserQueryTab.js
+++ b/FrontEnd/Modules/Admin/Scripts/WiserQueryTab.js
@@ -133,7 +133,7 @@ export class WiserQueryTab {
             });
 
             this.base.showNotification("notification", `Query is succesvol bijgewerkt`, "success");
-            await this.getQueries();
+            await this.getQueries(true, id);
         }
         catch (exception) {
             console.error("Error while updating query", exception);


### PR DESCRIPTION
When saving/updating an existing query in Wiser Management, the query would be deselected in the combobox, while all query data would remain in all the data fields. This change causes the same query to remain selected in the combobox so multiple updates in a row are possible without getting the error "select a query first".