### PR TITLE
Select new entity after creation

### DIFF
--- a/FrontEnd/Modules/Admin/Scripts/EntityTab.js
+++ b/FrontEnd/Modules/Admin/Scripts/EntityTab.js
@@ -270,10 +270,8 @@ export class EntityTab {
             this.base.showNotification("notification", `Entiteit succesvol toegevoegd`, "success");
             await this.reloadEntityList(true);
 
-            this.entitiesCombobox.one("dataBound", () => {
-                this.entitiesCombobox.select((dataItem) => {
-                    return dataItem.name === name;
-                });
+            this.entitiesCombobox.select((dataItem) => {
+                return dataItem.name === name;
             });
 
             // Select the entity tab again after creating a new entity.


### PR DESCRIPTION
After creating a new entity, the entities dropdown box did not select the new item.
The "databound" handler makes no sense if the code is waiting for the reloadEntityList to finish. The binding is done at this point, so simply select the new item.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205300519905989