### PR TITLE
add a convert for itemId field in FilesRepository

### DIFF
--- a/Api/Modules/Files/Services/Repository/FilesRepository.cs
+++ b/Api/Modules/Files/Services/Repository/FilesRepository.cs
@@ -80,7 +80,7 @@ ORDER BY isDirectory DESC, name ASC";
             model.ExpandedSpriteCssClass = Constants.OpenedDirectoryIconClass;
             model.Html = dataRow.Field<string>("html");
             model.PropertyName = dataRow.Field<string>("propertyName");
-            model.ItemId = dataRow.Field<ulong>("itemId");
+            model.ItemId = Convert.ToUInt64(dataRow["itemId"]);
             model.ContentType = dataRow.Field<string>("contentType");
             return model;
         }).ToList();


### PR DESCRIPTION
at one of our costumer this caused the image viewer to return a error and not open, this convert was already present for the id itself so now is also added to the item id, this resolved the issue.
asana:
https://app.asana.com/0/1201394730777422/1205352004770791/f