### PR TITLE
Fixed action button query parameter grid row delete button clipped off

### DIFF
--- a/FrontEnd/Modules/Admin/Scripts/EntityTab.js
+++ b/FrontEnd/Modules/Admin/Scripts/EntityTab.js
@@ -1799,7 +1799,7 @@ export class EntityTab {
             // open window and set to default
             $("#actionButtonPopupHtml").show();
             window.setOptions({
-                width: 1000,
+                width: 1200,
                 height: 800
             });
             // set to fields default
@@ -1831,7 +1831,7 @@ export class EntityTab {
             this.userParametersGrid.setDataSource(resetDs);
         } else {
             window = $("#actionButtonPopupHtml").kendoWindow({
-                width: 1000,
+                width: 1200,
                 height: 800
             }).data("kendoWindow");
 
@@ -1894,7 +1894,8 @@ export class EntityTab {
                 columns: [
                     {
                         field: "name",
-                        title: "Naam parameter"
+                        title: "Naam parameter",
+                        width: "200px"
                     },
                     {
                         field: "question",
@@ -1906,23 +1907,28 @@ export class EntityTab {
                         editor: fieldTypeDropDownList,
                         template: (event) => {
                             return event.fieldTypeId === "" ? event.fieldType.text : this.base.fieldTypesDropDown[event.fieldTypeId.toUpperCase()].text;
-                        }
+                        },
+                        width: "125px"
                     },
                     {
                         field: "value",
-                        title: "Standaardwaarde"
+                        title: "Standaardwaarde",
+                        width: "150px"
                     },
                     {
                         field: "format",
-                        title: "Format"
+                        title: "Format",
+                        width: "100px"
                     },
                     {
                         field: "queryId",
-                        title: "Query id"
+                        title: "Query id",
+                        width: "75px"
                     },
                     {
                         field: "gridHeight",
-                        title: "Grid hoogte"
+                        title: "Grid hoogte",
+                        width: "95px"
                     },
                     {
                         field: "dataTextField",
@@ -1946,8 +1952,9 @@ export class EntityTab {
                         command: [
                             { text: "↑", click: this.base.moveUp.bind(this.base) },
                             { text: "↓", click: this.base.moveDown.bind(this.base) },
-                            "destroy"
-                        ]
+                            { name: "destroy", text: "", iconClass: "k-icon k-i-delete" }
+                        ],
+                        width: "152px" // minimum needed to not have the delete button disappear
                     }
 
                 ]


### PR DESCRIPTION
When the command column in the grid is too narrow, the delete button gets clipped and ellipses are placed. However, the icon remains making it look broken. This change widens the window, giving enough room for each column, and removes the text from the delete button to have it use less room.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205184957053785