### PR TITLE
Incorrect error message on property add/delete

### DIFF
--- a/FrontEnd/Modules/Admin/Scripts/EntityTab.js
+++ b/FrontEnd/Modules/Admin/Scripts/EntityTab.js
@@ -3160,7 +3160,7 @@ entityProperties.options.saveValueAsItemLink = document.getElementById("saveValu
     selectTabInTreeView(tabName, alsoExpand = false) {
         const selectedTab = this.propertiesTreeView.dataSource.get(tabName);
         if (selectedTab === undefined) {
-            console.warn("Unable to open tab " + tabName + " in tree view");
+            console.warn(`Unable to open tab ${tabName} in tree view`);
             return;
         }
         const nodeToSelect = this.propertiesTreeView.findByUid(selectedTab.uid);

--- a/FrontEnd/Modules/Admin/Scripts/EntityTab.js
+++ b/FrontEnd/Modules/Admin/Scripts/EntityTab.js
@@ -320,13 +320,13 @@ export class EntityTab {
             await Promise.all(promises);
 
             await this.onEntitiesComboBoxSelect();
-
-            this.selectTabInTreeView(tabName, true);
         }
         catch (exception) {
             console.error("Error while trying to delete an entity property", exception);
             this.base.showNotification("notification", `Veld is niet succesvol aangemaakt, probeer het opnieuw`, "error");
         }
+        
+        this.selectTabInTreeView(tabName === "" ? "Gegevens" : tabName, true);
     }
 
     /**
@@ -356,12 +356,13 @@ export class EntityTab {
             this.base.showNotification("notification", `Veld succesvol verwijderd`, "success");
 
             await this.onEntitiesComboBoxSelect(this);
-            this.selectTabInTreeView(selectedProperty.tabName, true);
         }
         catch (exception) {
             console.error("Error while trying to delete an entity property", exception);
             this.base.showNotification("notification", `Veld is niet succesvol verwijderd, probeer het opnieuw`, "error");
         }
+        
+        this.selectTabInTreeView(selectedProperty.tabName, true);
     }
 
     /**
@@ -3158,6 +3159,10 @@ entityProperties.options.saveValueAsItemLink = document.getElementById("saveValu
 
     selectTabInTreeView(tabName, alsoExpand = false) {
         const selectedTab = this.propertiesTreeView.dataSource.get(tabName);
+        if (selectedTab === undefined) {
+            console.warn("Unable to open tab " + tabName + " in tree view");
+            return;
+        }
         const nodeToSelect = this.propertiesTreeView.findByUid(selectedTab.uid);
         this.propertiesTreeView.select(nodeToSelect);
         if (!alsoExpand) {


### PR DESCRIPTION
1. The crash happened in selectTabInTreeView which was inside the try-except scope, producing the incorrect add/remove failed error message.
2. Code is trying to open non-existing tabs in the treeview. It should try to open the default tree folder if tabName is empty.
3. Made selectTabInTreeView more defensive because it is possible the provided tab no longer exists (when the last property is deleted for example)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205322186023693