### PR TITLE
Fixed saving filter state of entitiesgrid

### DIFF
--- a/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
+++ b/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
@@ -229,32 +229,32 @@ if (customQueryGrid) {
     }
 }
     
-function mergeFilterData(data, newData)
-{
+function mergeFilterData(data, newData){
     // if grid had no filter data yet, the newData is all we have!
-    if (data === undefined)
+    if (data === undefined) {
         return newData;
+    }
     
     // newData.filters is usually length 1, but it doesn't hurt to support >1
     newData.filters.forEach(newFilter => {
         let i = data.filters.findIndex((f) => f.field === newFilter.field);
         
         // if the existing data already has a filter configured for this field, we are either removing it or changing it
-        if (i >= 0)
-        {
+        if (i >= 0) {
             // we are removing this filter
-            if (newFilter.operator == null) 
+            if (newFilter.operator == null) {
                 data.filters.splice(i, 1);
+            }
             // it exists and need to be changed
-            else 
-            {
+            else {
                 data.filters[i].operator = newFilter.operator;
                 data.filters[i].value = newFilter.value;
             }
         }
         // existing data does not have this filter, add it (if it's not a removal somehow)
-        else if (newFilter.operator != null)
+        else if (newFilter.operator != null) {
             data.filters.push(newFilter);
+        }
     });
     return data;
 }
@@ -890,10 +890,10 @@ async function generateGrid(data, model, columns) {
         filter: function (event) {            
             if (options.keepFiltersState !== false) {
                 try {
-                    if (event.field == null) // manual event trigger, all filters were removed
+                    if (event.field == null) { // manual event trigger, all filters were removed
                         dynamicItems.grids.saveGridViewState("sub_entities_grid_filters_{propertyId}", "{}");
-                    else
-                    {
+                    }
+                    else {
                         let mergedData = event.filter != null ?
                             mergeFilterData(event.sender.dataSource.filter(), event.filter) : // filter was added
                             mergeFilterData(event.sender.dataSource.filter(), { "filters": [{ "field": event.field, "operator": null }]}); // filter was removed

--- a/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
+++ b/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
@@ -229,6 +229,35 @@ if (customQueryGrid) {
     }
 }
     
+function mergeFilterData(data, newData)
+{
+    // if grid had no filter data yet, the newData is all we have!
+    if (data === undefined)
+        return newData;
+    
+    // newData.filters is usually length 1, but it doesn't hurt to support >1
+    newData.filters.forEach(newFilter => {
+        let i = data.filters.findIndex((f) => f.field === newFilter.field);
+        
+        // if the existing data already has a filter configured for this field, we are either removing it or changing it
+        if (i >= 0)
+        {
+            // we are removing this filter
+            if (newFilter.operator == null) 
+                data.filters.splice(i, 1);
+            // it exists and need to be changed
+            else 
+            {
+                data.filters[i].operator = newFilter.operator;
+                data.filters[i].value = newFilter.value;
+            }
+        }
+        // existing data does not have this filter, add it (if it's not a removal somehow)
+        else if (newFilter.operator != null)
+            data.filters.push(newFilter);
+    });
+    return data;
+}
 async function generateGrid(data, model, columns) {
     var toolbar = [];
     if (!options.toolbar || !options.toolbar.hideExportButton) {
@@ -858,9 +887,22 @@ async function generateGrid(data, model, columns) {
                 });
             }
         },
-        filter: function (event) {
+        filter: function (event) {            
             if (options.keepFiltersState !== false) {
-                dynamicItems.grids.saveGridViewState("sub_entities_grid_filters_{propertyId}", kendo.stringify(event.filter));
+                try {
+                    if (event.field == null) // manual event trigger, all filters were removed
+                        dynamicItems.grids.saveGridViewState("sub_entities_grid_filters_{propertyId}", "{}");
+                    else
+                    {
+                        let mergedData = event.filter != null ?
+                            mergeFilterData(event.sender.dataSource.filter(), event.filter) : // filter was added
+                            mergeFilterData(event.sender.dataSource.filter(), { "filters": [{ "field": event.field, "operator": null }]}); // filter was removed
+                        dynamicItems.grids.saveGridViewState("sub_entities_grid_filters_{propertyId}", kendo.stringify(mergedData));
+                    }
+                } catch (exception) {
+                    kendo.alert("Er is iets fout gegaan tijdens het opslaan van de filter instellingen voor dit grid. Probeer het nogmaals, of neem contact op met ons.");
+                    console.error(exception);
+                }
             }
         },
         change: dynamicItems.grids.onGridSelectionChange.bind(dynamicItems.grids)

--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -1504,6 +1504,8 @@ export class Grids {
         }
 
         grid.dataSource.filter({});
+        // manually trigger the filter event to save the state because the above call doesn't do so
+        grid.trigger("filter", { filter: null, field: null });
     }
 
     /**


### PR DESCRIPTION
The filter event (now) only contains the new filter state, not the existing ones. So to save the correct state I need to merge the new filter with the current grid filters. Also made sure the filter event is triggered when the filters are reset.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205063613165510