### PR TITLE
Disable updating moduleId in Wiser configuration - add watch command for easier use

### DIFF
--- a/Api/Modules/Modules/Services/ModulesService.cs
+++ b/Api/Modules/Modules/Services/ModulesService.cs
@@ -822,7 +822,6 @@ DELETE FROM {WiserTableNames.WiserPermission} WHERE module_id = ?id;";
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             clientDatabaseConnection.ClearParameters();
             clientDatabaseConnection.AddParameter("id", id);
-            clientDatabaseConnection.AddParameter("new_id", moduleSettingsModel.Id);
             clientDatabaseConnection.AddParameter("custom_query", moduleSettingsModel.CustomQuery);
             clientDatabaseConnection.AddParameter("count_query", moduleSettingsModel.CountQuery);
             clientDatabaseConnection.AddParameter("options", moduleSettingsModel.Options.ToString());
@@ -832,8 +831,7 @@ DELETE FROM {WiserTableNames.WiserPermission} WHERE module_id = ?id;";
             clientDatabaseConnection.AddParameter("group", moduleSettingsModel.Group);
 
             var query = $@"UPDATE {WiserTableNames.WiserModule}
-SET `id` = ?new_id,
-    `custom_query` = ?custom_query,
+SET `custom_query` = ?custom_query,
     `count_query` = ?count_query,
     `options` = IF(?options != '' AND ?options IS NOT NULL AND JSON_VALID(?options), ?options, ''),
     `name` = ?name,

--- a/FrontEnd/Modules/Admin/Scripts/ModuleTab.js
+++ b/FrontEnd/Modules/Admin/Scripts/ModuleTab.js
@@ -12,9 +12,9 @@ export class ModuleTab {
     }
 
     /**
-    * Setup all basis bindings for this module.
-    * Specific bindings (for buttons in certain pop-ups for example) will be set when they are needed.
-    */
+     * Setup all basis bindings for this module.
+     * Specific bindings (for buttons in certain pop-ups for example) will be set when they are needed.
+     */
     setupBindings() {
         $(".addModuleBtn").kendoButton({
             click: () => {
@@ -611,7 +611,7 @@ export class ModuleTab {
     }
 
     async setModulePropertiesToDefault() {
-        document.getElementById("moduleId").value = "";
+        document.getElementById("moduleId").innerHTML  = "";
         document.getElementById("moduleName").value = "";
 
         this.moduleType.value("");
@@ -624,7 +624,7 @@ export class ModuleTab {
     }
 
     async setModuleProperties(resultSet) {
-        document.getElementById("moduleId").value = resultSet.id;
+        document.getElementById("moduleId").innerHTML  = resultSet.id;
         document.getElementById("moduleName").value = typeof (resultSet.name) === "undefined" ? "" : resultSet.name;
 
         this.moduleIcon.value(resultSet.icon);
@@ -665,7 +665,9 @@ export class ModuleTab {
      */
     getCurrentModuleSettings() {
         const moduleIdElement = document.getElementById("moduleId");
-        if (moduleIdElement == null || isNaN(moduleIdElement.value)) {
+        const moduleId = parseInt(moduleIdElement.innerHTML);
+        
+        if (isNaN(moduleId)) {
             return null;
         }
 
@@ -692,7 +694,6 @@ export class ModuleTab {
             delete moduleOptions.entityType;
         }
 
-        const moduleId = parseInt(moduleIdElement.value);
         return new ModuleSettingsModel(
             moduleId,
             this.moduleCustomQuery.getValue(),

--- a/FrontEnd/Modules/Admin/Scripts/ModuleTab.js
+++ b/FrontEnd/Modules/Admin/Scripts/ModuleTab.js
@@ -624,7 +624,8 @@ export class ModuleTab {
     }
 
     async setModuleProperties(resultSet) {
-        document.getElementById("moduleId").innerHTML  = resultSet.id;
+        document.getElementById("moduleIdLabel").innerHTML = resultSet.id;
+        document.getElementById("moduleId").value = resultSet.id;
         document.getElementById("moduleName").value = typeof (resultSet.name) === "undefined" ? "" : resultSet.name;
 
         this.moduleIcon.value(resultSet.icon);
@@ -664,8 +665,7 @@ export class ModuleTab {
      * @returns {ModuleSettingsModel|null} The settings for the module, or null if no module has been selected.
      */
     getCurrentModuleSettings() {
-        const moduleIdElement = document.getElementById("moduleId");
-        const moduleId = parseInt(moduleIdElement.innerHTML);
+        const moduleId = Number.parseInt(document.getElementById("moduleId").value);
         
         if (isNaN(moduleId)) {
             return null;

--- a/FrontEnd/Modules/Admin/Views/Admin/Index.cshtml
+++ b/FrontEnd/Modules/Admin/Views/Admin/Index.cshtml
@@ -71,7 +71,8 @@
                                             <label>ID van de module</label>
                                         </h4>
                                         <span class="k-widget k-input k-state-default">
-                                            <label id="moduleId" class="textField k-input" style="text-indent: 10px;" ></label>
+                                            <input type="hidden" id="moduleId" />
+                                            <label id="moduleIdLabel" class="textField k-input" style="text-indent: 10px;"></label>
                                         </span>
                                     </div>
                                     <div class="item" style="width: 50%;">

--- a/FrontEnd/Modules/Admin/Views/Admin/Index.cshtml
+++ b/FrontEnd/Modules/Admin/Views/Admin/Index.cshtml
@@ -71,7 +71,7 @@
                                             <label>ID van de module</label>
                                         </h4>
                                         <span class="k-widget k-input k-state-default">
-                                            <input id="moduleId" type="text" class="textField k-input" autocomplete="off" />
+                                            <label id="moduleId" class="textField k-input" style="text-indent: 10px;" ></label>
                                         </span>
                                     </div>
                                     <div class="item" style="width: 50%;">

--- a/FrontEnd/package.json
+++ b/FrontEnd/package.json
@@ -4,7 +4,8 @@
   "author": "Happy Geeks B.V.",
   "scripts": {
     "build-dev": "webpack --mode=development",
-    "build-prod": "webpack --mode=production"
+    "build-prod": "webpack --mode=production",
+    "watch": "node_modules\\.bin\\webpack --mode=development -w"
   },
   "main": "main.js",
   "dependencies": {
@@ -40,8 +41,7 @@
     "sass-loader": "^13.2.1",
     "style-loader": "^3.3.3",
     "vue-cli-plugin-vue-next": "~0.1.4",
-    "webpack": "^5.76.2",
-    "webpack-cli": "^5.0.1"
+    "webpack-cli": "^5.1.4"
   },
   "license": "ISC"
 }

--- a/FrontEnd/package.json
+++ b/FrontEnd/package.json
@@ -4,8 +4,7 @@
   "author": "Happy Geeks B.V.",
   "scripts": {
     "build-dev": "webpack --mode=development",
-    "build-prod": "webpack --mode=production",
-    "watch": "node_modules\\.bin\\webpack --mode=development -w"
+    "build-prod": "webpack --mode=production"
   },
   "main": "main.js",
   "dependencies": {

--- a/FrontEnd/package.json
+++ b/FrontEnd/package.json
@@ -40,7 +40,7 @@
     "sass-loader": "^13.2.1",
     "style-loader": "^3.3.3",
     "vue-cli-plugin-vue-next": "~0.1.4",
-    "webpack-cli": "^5.1.4"
+    "webpack-cli": "^5.0.1"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
Removed possibility of updating the module ID. Also added a watch command reference to the package.json for easier use.

Ticket: https://app.asana.com/0/1201027711166952/1203115791838029/f

Screenshot below is changed view; moduleID inputfield has been changed to a label.
![image](https://github.com/happy-geeks/wiser/assets/145993942/0d496f65-46eb-472d-9813-4cceb7966c83)
