### PR TITLE
Add label of module name to branch creation popup ( if no module nameis available module + moduleId will be shown instead)

### DIFF
--- a/FrontEnd/Core/Views/Home/Index.cshtml
+++ b/FrontEnd/Core/Views/Home/Index.cshtml
@@ -234,7 +234,7 @@
                                         </td>
                                     </tr>
                                     <tr v-for="entity in entitiesForBranches" :key="entity.id">
-                                        <td v-if="entity.moduleName === ''">Module #{{ entity.moduleId }} --> {{ entity.displayName }}</td>
+                                        <td v-if="!entity.moduleName">Module #{{ entity.moduleId }} --> {{ entity.displayName }}</td>
                                         <td v-else>{{ entity.moduleName }} --> {{ entity.displayName }}</td>
                                         <td>{{ entity.totalItems }}</td>
                                         <td>

--- a/FrontEnd/Core/Views/Home/Index.cshtml
+++ b/FrontEnd/Core/Views/Home/Index.cshtml
@@ -234,7 +234,8 @@
                                         </td>
                                     </tr>
                                     <tr v-for="entity in entitiesForBranches" :key="entity.id">
-                                        <td>{{ entity.displayName }}</td>
+                                        <td v-if="entity.moduleName === ''">Module #{{ entity.moduleId }} --> {{ entity.displayName }}</td>
+                                        <td v-else>{{ entity.moduleName }} --> {{ entity.displayName }}</td>
                                         <td>{{ entity.totalItems }}</td>
                                         <td>
                                             <select v-model="createBranchSettings.entities[entity.id].mode" v-if="createBranchSettings.entities[entity.id]">


### PR DESCRIPTION
Added text with the name of the related module. If item has no related module, Module  #ModuleId will be shown instead.
Did not change order of items shown - still based on items, not on module name.

Ticket: https://app.asana.com/0/1201027711166952/1205666113042076/f

![image](https://github.com/happy-geeks/wiser/assets/145993942/1176d60d-52c0-4255-b937-cdf2cf854330)
