### PR TITLE
Replaced text fields in Template histories with actual diff fields

### DIFF
--- a/Api/Modules/Templates/Models/History/HistoryVersionModel.cs
+++ b/Api/Modules/Templates/Models/History/HistoryVersionModel.cs
@@ -10,6 +10,11 @@ namespace Api.Modules.Templates.Models.History
     public class HistoryVersionModel
     {
         /// <summary>
+        /// Get or sets the name.
+        /// </summary>
+        public string Name { get; set; }
+        
+        /// <summary>
         /// Get or sets the version number.
         /// </summary>
         public int Version { get; set; }

--- a/Api/Modules/Templates/Models/History/TemplateHistoryModel.cs
+++ b/Api/Modules/Templates/Models/History/TemplateHistoryModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using GeeksCoreLibrary.Modules.Templates.Enums;
 
 namespace Api.Modules.Templates.Models.History
 {
@@ -32,12 +33,12 @@ namespace Api.Modules.Templates.Models.History
         /// <summary>
         /// Gets or sets a dictionary of the changes done in a template 
         /// </summary>
-        public Dictionary<string, KeyValuePair<object, object>> TemplateChanges { get; set; }
+        public Dictionary<string, Tuple<object, object, TemplateTypes>> TemplateChanges { get; set; }
         
         /// <summary>
         /// Gets or sets a dictionary of the changes done in a template linked to the current template
         /// </summary>
-        public Dictionary<string, KeyValuePair<object, object>> LinkedTemplateChanges { get; set; }
+        public Dictionary<string, Tuple<object, object, TemplateTypes>> LinkedTemplateChanges { get; set; }
         
         /// <summary>
         /// Gets or sets a list of changes done in the Dynamic Content of a template
@@ -63,8 +64,8 @@ namespace Api.Modules.Templates.Models.History
             this.Version = version;
             this.ChangedOn = changedOn;
             this.ChangedBy = changedBy;
-            this.TemplateChanges = new Dictionary<string, KeyValuePair<object, object>>();
-            this.LinkedTemplateChanges = new Dictionary<string, KeyValuePair<object, object>>();
+            this.TemplateChanges = new Dictionary<string, Tuple<object, object, TemplateTypes>>();
+            this.LinkedTemplateChanges = new Dictionary<string, Tuple<object, object, TemplateTypes>>();
             this.DynamicContentChanges = new List<HistoryVersionModel>();
         }
         

--- a/Api/Modules/Templates/Services/DataLayer/HistoryDataService.cs
+++ b/Api/Modules/Templates/Services/DataLayer/HistoryDataService.cs
@@ -40,7 +40,8 @@ namespace Api.Modules.Templates.Services.DataLayer
     changed_by,
     component,
     component_mode,
-    settings 
+    settings,
+    title
 FROM {WiserTableNames.WiserDynamicContent} 
 WHERE content_id = ?contentId 
 ORDER BY version DESC
@@ -51,6 +52,7 @@ LIMIT ?limit, ?offset");
             {
                 resultDict.Add(new HistoryVersionModel
                 {
+                    Name = row.Field<string>("title"),
                     Version = row.Field<int>("version"),
                     ChangedOn = row.Field<DateTime>("changed_on"),
                     ChangedBy = row.Field<string>("changed_by"),

--- a/Api/Modules/Templates/Services/HistoryService.cs
+++ b/Api/Modules/Templates/Services/HistoryService.cs
@@ -15,6 +15,7 @@ using Api.Modules.Templates.Models.History;
 using Api.Modules.Templates.Models.Other;
 using Api.Modules.Templates.Models.Template;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
+using GeeksCoreLibrary.Modules.Templates.Enums;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -158,43 +159,43 @@ namespace Api.Modules.Templates.Services
         {
             var historyModel = new TemplateHistoryModel(newVersion.TemplateId, newVersion.Version, newVersion.ChangedOn, newVersion.ChangedBy);
 
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("name", newVersion.Name, oldVersion.Name, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("editorValue", newVersion.EditorValue, oldVersion.EditorValue, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("cacheMinutes", newVersion.CacheMinutes, oldVersion.CacheMinutes, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("cacheLocation", newVersion.CacheLocation, oldVersion.CacheLocation, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("cachePerUrl", newVersion.CachePerUrl, oldVersion.CachePerUrl, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("cacheUsingRegex", newVersion.CacheUsingRegex, oldVersion.CacheUsingRegex, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("cachePerHostName", newVersion.CachePerHostName, oldVersion.CachePerHostName, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("cachePerQueryString", newVersion.CachePerQueryString, oldVersion.CachePerQueryString, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("cacheRegex", newVersion.CacheRegex, oldVersion.CacheRegex, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("loginRequired", newVersion.LoginRequired, oldVersion.LoginRequired, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("loginRole", newVersion.LoginRoles == null ? "" : String.Join(",", newVersion.LoginRoles), oldVersion.LoginRoles == null ? "" : String.Join(",", oldVersion.LoginRoles), historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("insertMode", newVersion.InsertMode, oldVersion.InsertMode, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("loadAlways", newVersion.LoadAlways, oldVersion.LoadAlways, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("disableMinifier", newVersion.DisableMinifier, oldVersion.DisableMinifier, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("urlRegex", newVersion.UrlRegex, oldVersion.UrlRegex, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("externalFiles", String.Join(";", newVersion.ExternalFiles ?? new List<string>()), String.Join(";", oldVersion.ExternalFiles ?? new List<string>()), historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("groupingCreateObjectInsteadOfArray", newVersion.GroupingCreateObjectInsteadOfArray, oldVersion.GroupingCreateObjectInsteadOfArray, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("groupingPrefix", newVersion.GroupingPrefix, oldVersion.GroupingPrefix, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("groupingKey", newVersion.GroupingKey, oldVersion.GroupingKey, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("groupingKeyColumnName", newVersion.GroupingKeyColumnName, oldVersion.GroupingKeyColumnName, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("groupingValueColumnName", newVersion.GroupingValueColumnName, oldVersion.GroupingValueColumnName, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("isScssIncludeTemplate", newVersion.IsScssIncludeTemplate, oldVersion.IsScssIncludeTemplate, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("useInWiserHtmlEditors", newVersion.UseInWiserHtmlEditors, oldVersion.UseInWiserHtmlEditors, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("preLoadQuery", newVersion.PreLoadQuery, oldVersion.PreLoadQuery, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("returnNotFoundWhenPreLoadQueryHasNoData", newVersion.ReturnNotFoundWhenPreLoadQueryHasNoData, oldVersion.ReturnNotFoundWhenPreLoadQueryHasNoData, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("routineType", newVersion.RoutineType, oldVersion.RoutineType, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("routineParameters", newVersion.RoutineParameters, oldVersion.RoutineParameters, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("routineReturnType", newVersion.RoutineReturnType, oldVersion.RoutineReturnType, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("triggerTiming", newVersion.TriggerTiming, oldVersion.TriggerTiming, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("triggerEvent", newVersion.TriggerEvent, oldVersion.TriggerEvent, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("triggerTableName", newVersion.TriggerTableName, oldVersion.TriggerTableName, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("isDefaultHeader", newVersion.IsDefaultHeader, oldVersion.IsDefaultHeader, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("isDefaultFooter", newVersion.IsDefaultFooter, oldVersion.IsDefaultFooter, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("defaultHeaderFooterRegex", newVersion.DefaultHeaderFooterRegex, oldVersion.DefaultHeaderFooterRegex, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("isPartial", newVersion.IsPartial, oldVersion.IsPartial, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("widgetContent", newVersion.WidgetContent, oldVersion.WidgetContent, historyModel);
-            CheckIfValuesMatchAndSaveChangesToHistoryModel("widgetLocation", newVersion.WidgetLocation, oldVersion.WidgetLocation, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("name", TemplateTypes.Normal, newVersion.Name, oldVersion.Name, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("editorValue", TemplateTypes.Html, newVersion.EditorValue, oldVersion.EditorValue, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("cacheMinutes", TemplateTypes.Normal, newVersion.CacheMinutes, oldVersion.CacheMinutes, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("cacheLocation", TemplateTypes.Normal, newVersion.CacheLocation, oldVersion.CacheLocation, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("cachePerUrl", TemplateTypes.Normal, newVersion.CachePerUrl, oldVersion.CachePerUrl, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("cacheUsingRegex", TemplateTypes.Normal, newVersion.CacheUsingRegex, oldVersion.CacheUsingRegex, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("cachePerHostName", TemplateTypes.Normal, newVersion.CachePerHostName, oldVersion.CachePerHostName, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("cachePerQueryString", TemplateTypes.Normal, newVersion.CachePerQueryString, oldVersion.CachePerQueryString, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("cacheRegex", TemplateTypes.Normal, newVersion.CacheRegex, oldVersion.CacheRegex, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("loginRequired", TemplateTypes.Normal, newVersion.LoginRequired, oldVersion.LoginRequired, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("loginRole", TemplateTypes.Normal, newVersion.LoginRoles == null ? "" : String.Join(",", newVersion.LoginRoles), oldVersion.LoginRoles == null ? "" : String.Join(",", oldVersion.LoginRoles), historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("insertMode", TemplateTypes.Normal, newVersion.InsertMode, oldVersion.InsertMode, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("loadAlways", TemplateTypes.Normal, newVersion.LoadAlways, oldVersion.LoadAlways, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("disableMinifier", TemplateTypes.Normal, newVersion.DisableMinifier, oldVersion.DisableMinifier, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("urlRegex", TemplateTypes.Normal, newVersion.UrlRegex, oldVersion.UrlRegex, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("externalFiles", TemplateTypes.Normal, String.Join(";", newVersion.ExternalFiles ?? new List<string>()), String.Join(";", oldVersion.ExternalFiles ?? new List<string>()), historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("groupingCreateObjectInsteadOfArray", TemplateTypes.Normal, newVersion.GroupingCreateObjectInsteadOfArray, oldVersion.GroupingCreateObjectInsteadOfArray, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("groupingPrefix", TemplateTypes.Normal, newVersion.GroupingPrefix, oldVersion.GroupingPrefix, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("groupingKey", TemplateTypes.Normal, newVersion.GroupingKey, oldVersion.GroupingKey, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("groupingKeyColumnName", TemplateTypes.Normal, newVersion.GroupingKeyColumnName, oldVersion.GroupingKeyColumnName, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("groupingValueColumnName", TemplateTypes.Normal, newVersion.GroupingValueColumnName, oldVersion.GroupingValueColumnName, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("isScssIncludeTemplate", TemplateTypes.Normal, newVersion.IsScssIncludeTemplate, oldVersion.IsScssIncludeTemplate, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("useInWiserHtmlEditors", TemplateTypes.Normal, newVersion.UseInWiserHtmlEditors, oldVersion.UseInWiserHtmlEditors, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("preLoadQuery", TemplateTypes.Query, newVersion.PreLoadQuery, oldVersion.PreLoadQuery, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("returnNotFoundWhenPreLoadQueryHasNoData", TemplateTypes.Normal, newVersion.ReturnNotFoundWhenPreLoadQueryHasNoData, oldVersion.ReturnNotFoundWhenPreLoadQueryHasNoData, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("routineType", TemplateTypes.Normal, newVersion.RoutineType, oldVersion.RoutineType, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("routineParameters", TemplateTypes.Normal, newVersion.RoutineParameters, oldVersion.RoutineParameters, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("routineReturnType", TemplateTypes.Normal, newVersion.RoutineReturnType, oldVersion.RoutineReturnType, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("triggerTiming", TemplateTypes.Normal, newVersion.TriggerTiming, oldVersion.TriggerTiming, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("triggerEvent", TemplateTypes.Normal, newVersion.TriggerEvent, oldVersion.TriggerEvent, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("triggerTableName", TemplateTypes.Normal, newVersion.TriggerTableName, oldVersion.TriggerTableName, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("isDefaultHeader", TemplateTypes.Normal, newVersion.IsDefaultHeader, oldVersion.IsDefaultHeader, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("isDefaultFooter", TemplateTypes.Normal, newVersion.IsDefaultFooter, oldVersion.IsDefaultFooter, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("defaultHeaderFooterRegex", TemplateTypes.Normal, newVersion.DefaultHeaderFooterRegex, oldVersion.DefaultHeaderFooterRegex, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("isPartial", TemplateTypes.Normal, newVersion.IsPartial, oldVersion.IsPartial, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("widgetContent", TemplateTypes.Html, newVersion.WidgetContent, oldVersion.WidgetContent, historyModel);
+            CheckIfValuesMatchAndSaveChangesToHistoryModel("widgetLocation", TemplateTypes.Normal, newVersion.WidgetLocation, oldVersion.WidgetLocation, historyModel);
 
             var oldLinkedTemplates = newVersion.LinkedTemplates.RawLinkList.Split(new [] { ',' }, StringSplitOptions.RemoveEmptyEntries);
             var newLinkedTemplates = oldVersion.LinkedTemplates.RawLinkList.Split(new [] { ',' }, StringSplitOptions.RemoveEmptyEntries);
@@ -205,7 +206,7 @@ namespace Api.Modules.Templates.Services
                 {
                     if (!newLinkedTemplates.Contains(item))
                     {
-                        historyModel.LinkedTemplateChanges.Add(item.Split(";")[1], new KeyValuePair<object, object>(true, false));
+                        historyModel.LinkedTemplateChanges.Add(item.Split(";")[1], new (true, false, TemplateTypes.Normal));
                     }
                 }
             }
@@ -215,7 +216,7 @@ namespace Api.Modules.Templates.Services
                 {
                     if (!oldLinkedTemplates.Contains(item))
                     {
-                        historyModel.LinkedTemplateChanges.Add(item.Split(";")[1], new KeyValuePair<object, object>(false, true));
+                        historyModel.LinkedTemplateChanges.Add(item.Split(";")[1], new (false, true, TemplateTypes.Normal));
                     }
                 }
             }
@@ -230,7 +231,7 @@ namespace Api.Modules.Templates.Services
         /// <param name="newValue">The new value of the property</param>
         /// <param name="oldValue">The old value of the property</param>
         /// <param name="templateModel">The TemplateHistoryModel to which differences will be saved</param>
-        private void CheckIfValuesMatchAndSaveChangesToHistoryModel(string propName, object newValue, object oldValue, TemplateHistoryModel templateModel)
+        private void CheckIfValuesMatchAndSaveChangesToHistoryModel(string propName, TemplateTypes type, object newValue, object oldValue, TemplateHistoryModel templateModel)
         {
             if (Equals(newValue, oldValue))
             {
@@ -243,7 +244,7 @@ namespace Api.Modules.Templates.Services
                 return;
             }
 
-            templateModel.TemplateChanges.Add(propName, new KeyValuePair<object, object>(newValue, oldValue));
+            templateModel.TemplateChanges.Add(propName, new (newValue, oldValue, type));
         }
 
         /// <summary>

--- a/FrontEnd/Modules/Base/Css/diff2html.custom.css
+++ b/FrontEnd/Modules/Base/Css/diff2html.custom.css
@@ -1,0 +1,8 @@
+.d2h-diff-table {
+    background-color: white;
+    font-size: 12px;
+}
+
+.d2h-code-side-linenumber {
+	cursor: default !important;
+}

--- a/FrontEnd/Modules/Base/Scss/base.scss
+++ b/FrontEnd/Modules/Base/Scss/base.scss
@@ -4,3 +4,4 @@
 @import "../../Base/Css/icons.css";
 @import "../../Base/Css/variables.css";
 @import "../../Base/Css/masterpage.css";
+@import "../../Base/Css/diff2html.custom.css";

--- a/FrontEnd/Modules/Templates/Css/DynamicContent.css
+++ b/FrontEnd/Modules/Templates/Css/DynamicContent.css
@@ -113,6 +113,7 @@
 
 .historyContainer .col-12 {
     flex-basis: 100%;
+	width: 0;
 }
 
 .historyHeader .col {

--- a/FrontEnd/Modules/Templates/Css/Templates.css
+++ b/FrontEnd/Modules/Templates/Css/Templates.css
@@ -435,6 +435,7 @@ footer {
 
 .historyContainer .col-12 {
     flex-basis: 100%;
+	width: 0;
 }
 
 .historyHeader .col {
@@ -519,9 +520,7 @@ footer {
 }
 
 .historyDynamic {
-    border-top: 1px solid var(--body-color);
-    padding-top: 15px;
-    margin-top: 15px;
+    margin-left: 20px;
 }
 
 /** DYNAMIC CONTENT GRID **/

--- a/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
+++ b/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
@@ -289,8 +289,14 @@ const moduleSettings = {
                 codeMirrorInstance.refresh();
             });
             
-            if (window.parent && event.item.classList.contains("history-tab"))
-                window.parent.Templates.createHistoryDiffFields(document.querySelector("#right-pane div.historyContainer"));
+            if (event.item.classList.contains("history-tab")) {
+                if (window.parent) {
+                    window.parent.Templates.createHistoryDiffFields(document.querySelector("#right-pane div.historyContainer"));
+                } else {
+                    kendo.alert("De history kan alleen goed weergegeven worden in een iframe.");
+                    console.warn("Unable to create diff fields for history listing");
+                }
+            }
         }
 
         async reloadComponentModes(newComponent, newComponentMode) {

--- a/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
+++ b/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
@@ -289,8 +289,8 @@ const moduleSettings = {
                 codeMirrorInstance.refresh();
             });
             
-            if (event.item.classList.contains("history-tab"))
-                window.parent.Templates.createHistoryDiffFields(document.getElementById("right-pane").querySelector("div.historyContainer"));
+            if (window.parent && event.item.classList.contains("history-tab"))
+                window.parent.Templates.createHistoryDiffFields(document.querySelector("#right-pane div.historyContainer"));
         }
 
         async reloadComponentModes(newComponent, newComponentMode) {
@@ -632,7 +632,8 @@ const moduleSettings = {
                 });
 
                 document.getElementsByClassName("historyContainer")[0].insertAdjacentHTML("beforeend", historyRowsHtml);
-                window.parent.Templates.createHistoryDiffFields(document.getElementById("right-pane").querySelector("div.historyContainer"));
+                if (window.parent)
+                    window.parent.Templates.createHistoryDiffFields(document.querySelector("#right-pane div.historyContainer"));
                 this.lastLoadedHistoryPart++;
             } catch (exception) {
                 kendo.alert("Er is iets fout gegaan met het laden van de historie. Probeer het a.u.b. opnieuw of neem contact op met ons.");

--- a/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
+++ b/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
@@ -3,6 +3,7 @@ import {Misc, Wiser} from "../../Base/Scripts/Utils.js";
 import "../../Base/Scripts/Processing.js";
 import {Preview} from "./Preview.js";
 import "../Css/DynamicContent.css";
+import "diff2html/bundles/css/diff2html.min.css"
 
 require("@progress/kendo-ui/js/kendo.notification.js");
 require("@progress/kendo-ui/js/kendo.button.js");
@@ -287,6 +288,9 @@ const moduleSettings = {
 
                 codeMirrorInstance.refresh();
             });
+            
+            if (event.item.classList.contains("history-tab"))
+                window.parent.Templates.createHistoryDiffFields(document.getElementById("right-pane").querySelector("div.historyContainer"));
         }
 
         async reloadComponentModes(newComponent, newComponentMode) {
@@ -628,6 +632,7 @@ const moduleSettings = {
                 });
 
                 document.getElementsByClassName("historyContainer")[0].insertAdjacentHTML("beforeend", historyRowsHtml);
+                window.parent.Templates.createHistoryDiffFields(document.getElementById("right-pane").querySelector("div.historyContainer"));
                 this.lastLoadedHistoryPart++;
             } catch (exception) {
                 kendo.alert("Er is iets fout gegaan met het laden van de historie. Probeer het a.u.b. opnieuw of neem contact op met ons.");

--- a/FrontEnd/Modules/Templates/Scripts/Templates.js
+++ b/FrontEnd/Modules/Templates/Scripts/Templates.js
@@ -2459,8 +2459,8 @@ const moduleSettings = {
          * @param {Element} container The container that will be searched for div.diffField elements.
          */
         createHistoryDiffFields(container) {
-            const Diff = require('diff');
-            const pretty = require('pretty');
+            const Diff = require("diff");
+            const pretty = require("pretty");
             
             let fields = container.querySelectorAll("div.diffField");
             for (let i = 0; i < fields.length; i++) {

--- a/FrontEnd/Modules/Templates/Scripts/Templates.js
+++ b/FrontEnd/Modules/Templates/Scripts/Templates.js
@@ -4,6 +4,8 @@ import "../../Base/Scripts/Processing.js";
 import {Preview} from "./Preview.js";
 import {TemplateConnectedUsers} from "./TemplateConnectedUsers.js";
 import "../Css/Templates.css";
+import * as Diff2Html from "diff2html/lib/diff2html"
+import "diff2html/bundles/css/diff2html.min.css"
 
 require("@progress/kendo-ui/js/kendo.notification.js");
 require("@progress/kendo-ui/js/kendo.button.js");
@@ -2400,6 +2402,7 @@ const moduleSettings = {
                         this.loadNextHistoryPart();
                     }
                 });
+                this.createHistoryDiffFields(document.getElementById("historyContainer"));
             } catch (exception) {
                 kendo.alert("Er is iets fout gegaan met het laden van de historie. Probeer het a.u.b. opnieuw of neem contact op met ons.");
                 console.error(exception);
@@ -2440,6 +2443,7 @@ const moduleSettings = {
                 });
 
                 document.getElementById("historyContainer").insertAdjacentHTML("beforeend", historyTabPart);
+                this.createHistoryDiffFields(document.getElementById("historyContainer"));
                 this.lastLoadedHistoryPartNumber++;
             } catch (exception) {
                 kendo.alert("Er is iets fout gegaan met het laden van de historie. Probeer het a.u.b. opnieuw of neem contact op met ons.");
@@ -2448,6 +2452,42 @@ const moduleSettings = {
 
             window.processing.removeProcess(process);
             this.loadingNextPart = false;
+        }
+
+        /**
+         * Replaces all div.diffField elements with diff2html diff interfaces.
+         * @param {Element} container The container that will be searched for div.diffField elements.
+         */
+        createHistoryDiffFields(container) {
+            const Diff = require('diff');
+            const pretty = require('pretty');
+            
+            let fields = container.querySelectorAll("div.diffField");
+            for (let i = 0; i < fields.length; i++) {
+                let field = fields[i];
+                let oldValue = field.querySelector("span.oldValue")?.getAttribute("value");
+                let newValue = field.querySelector("span.newValue")?.getAttribute("value");
+                const fieldName = field.getAttribute("field-name");
+                const dataType = field.getAttribute("data-type");
+                switch (dataType) { // TemplateTypes enum
+                    case "Html": // Html is saved without whitespace in the database, so we need to make it readable first
+                        oldValue = !oldValue ? "" : pretty(oldValue, { ocd: false });
+                        newValue = !newValue ? "" : pretty(newValue, { ocd: false });
+                        break;
+                    default:
+                        oldValue = !oldValue ? "" : oldValue;
+                        newValue = !newValue ? "" : newValue;
+                }
+                
+                const diff = Diff.createTwoFilesPatch(fieldName, fieldName, oldValue, newValue);                
+                field.innerHTML = Diff2Html.html(diff, {
+                    drawFileList: false,
+                    matching: "words",
+                    outputFormat: "side-by-side"
+                });
+                
+                field.classList.remove("diffField");
+            }
         }
 
         /**
@@ -2667,7 +2707,7 @@ const moduleSettings = {
                 await this.updateRenderingDataOnMeasurementsTab(templateId);
                 this.renderingLogsChart.resize();
             } catch (exception) {
-                kendo.alert("Er is iets fout gegaan met het laden van de historie. Probeer het a.u.b. opnieuw of neem contact op met ons.");
+                kendo.alert("Er is iets fout gegaan met het laden van de metingen. Probeer het a.u.b. opnieuw of neem contact op met ons.");
                 console.error(exception);
             }
 

--- a/FrontEnd/Modules/Templates/Views/DynamicContent/Partials/DynamicContentHistoryRows.cshtml
+++ b/FrontEnd/Modules/Templates/Views/DynamicContent/Partials/DynamicContentHistoryRows.cshtml
@@ -5,8 +5,8 @@
 {
     <div class="row historyLine" data-history-version="@historyVersion.Version">
         <div class="col col-12 historyTagline">
-            <span><span class="k-icon k-i-edit"></span> Versie @historyVersion.Version |</span>
-            <span><span class="k-icon k-i-calendar"></span> @historyVersion.GetDisplayChangedOn() |</span>
+            <span><span class="k-icon k-i-edit"></span><b> Versie @historyVersion.Version </b>| </span>
+            <span><span class="k-icon k-i-calendar"></span> @historyVersion.GetDisplayChangedOn() | </span>
             <span><span class="k-icon k-i-user"></span> door @historyVersion.ChangedBy</span>
         </div>
         @if (historyVersion.Changes == null || !historyVersion.Changes.Any())
@@ -17,10 +17,9 @@
         }
         else
         {
-            @foreach (var (oldVersion, newVersion) in historyVersion.ChangedFields)
+            @foreach (var pair in historyVersion.ChangedFields)
             {
-                <partial name="/Modules/Templates/Views/DynamicContent/Partials/HistoryInputGenerator.cshtml" model="oldVersion" />
-                <partial name="/Modules/Templates/Views/DynamicContent/Partials/HistoryInputGenerator.cshtml" model="newVersion" />
+                <partial name="/Modules/Templates/Views/DynamicContent/Partials/HistoryInputGenerator.cshtml" model="pair" />
             }
         }
     </div>

--- a/FrontEnd/Modules/Templates/Views/DynamicContent/Partials/HistoryInputGenerator.cshtml
+++ b/FrontEnd/Modules/Templates/Views/DynamicContent/Partials/HistoryInputGenerator.cshtml
@@ -1,166 +1,155 @@
 ﻿@using GeeksCoreLibrary.Core.Cms.Attributes
 @using Api.Core.Helpers
-@model FrontEnd.Modules.Templates.Models.FieldViewModel
+@using FrontEnd.Modules.Templates.Models
+@* @model FrontEnd.Modules.Templates.Models.FieldViewModel *@
+@model (FrontEnd.Modules.Templates.Models.FieldViewModel oldVersion, FrontEnd.Modules.Templates.Models.FieldViewModel newVersion)
 
-@{ var className = $"col col-{(Model.IsSubField ? 12 : 6)}"; }
-@try
-{
-    @switch (Model.CmsPropertyAttribute.TextEditorType)
+@{ RenderHtml(Model.oldVersion, Model.newVersion); }
+
+@{
+    void RenderHtml(FieldViewModel Model, FieldViewModel other = null)
     {
-        case CmsAttributes.CmsTextEditorType.Auto when Model.PropertyInfo.PropertyType.IsEnum:
-            <div class="@className">
-                <div class="item" data-label-style="float" data-label-width="0">
-                    <h4><label>@Model.PrettyName</label></h4>
-                    <span class="k-widget k-input k-state-default">
-                        @{
-                            var value = Model.Value;
-                            if (Int32.TryParse(Model.Value.ToString(), out var intValue))
-                            {
-                                value = Enum.GetName(Model.PropertyInfo.PropertyType, intValue);
-                            }
-                        }
-                        <input type="text" class="textField k-input" autocomplete="off" value="@value" data-history-property="@Model.Name" disabled>
-                    </span>
-                </div>
-            </div>
-            break;
+        if (Model == null) return;
 
-        case CmsAttributes.CmsTextEditorType.Auto when TypeHelpers.IsNumericType(Model.PropertyInfo.PropertyType) || Model.PropertyInfo.PropertyType == typeof(string):
-        case CmsAttributes.CmsTextEditorType.TextField:
-            <div class="@className">
-                <div class="item" data-label-style="float" data-label-width="0">
-                    <h4><label>@Model.PrettyName</label></h4>
-                    <span class="k-widget k-input k-state-default">
-                        <input type="text" class="textField k-input" autocomplete="off" value="@Model.Value" data-history-property="@Model.Name" disabled>
-                    </span>
-                </div>
-            </div>
-            break;
+        try
+        {
+            @switch (Model.CmsPropertyAttribute.TextEditorType)
+            {
+                case CmsAttributes.CmsTextEditorType.Auto when Model.PropertyInfo.PropertyType.IsEnum:
+                    <div class="col col-6">
+                        <div class="item" data-label-style="float" data-label-width="0">
+                            <h4><label>@Model.PrettyName</label></h4>
+                            <span class="k-widget k-input k-state-default">
+                                @{
+                                    var value = Model.Value;
+                                    if (Int32.TryParse(Model.Value.ToString(), out var intValue))
+                                    {
+                                        value = Enum.GetName(Model.PropertyInfo.PropertyType, intValue);
+                                    }
+                                }
+                                <input type="text" class="textField k-input" autocomplete="off" value="@value" data-history-property="@Model.Name" disabled>
+                            </span>
+                        </div>
+                    </div>
+                    RenderHtml(other);
+                    break;
 
-        case CmsAttributes.CmsTextEditorType.Auto when Model.PropertyInfo.PropertyType == typeof(bool):
-            <div class="@className checkLine">
-                <div class="item" data-label-style="normal" data-label-width="0">
-                    <span class="inline">
-                        <label class="checkbox">
-                            <input type="checkbox" value="@Model.Name" @(Model.Value != null && (string)Model.Value != "" && (bool)Model.Value ? "checked" : "") data-history-property="@Model.Name" disabled>
-                            <span>@Model.PrettyName</span>
-                        </label>
-                    </span>
-                </div>
-            </div>
-            break;
+                case CmsAttributes.CmsTextEditorType.Auto when TypeHelpers.IsNumericType(Model.PropertyInfo.PropertyType) || Model.PropertyInfo.PropertyType == typeof(string):
+                case CmsAttributes.CmsTextEditorType.TextField:
+                    <div class="col col-6">
+                        <div class="item" data-label-style="float" data-label-width="0">
+                            <h4><label>@Model.PrettyName</label></h4>
+                            <span class="k-widget k-input k-state-default">
+                                <input type="text" class="textField k-input" autocomplete="off" value="@Model.Value" data-history-property="@Model.Name" disabled>
+                            </span>
+                        </div>
+                    </div>
+                    RenderHtml(other);
+                    break;
 
-        case CmsAttributes.CmsTextEditorType.Auto when Model.PropertyInfo.PropertyType.IsGenericType && (Model.PropertyInfo.PropertyType.GetGenericTypeDefinition() == typeof(SortedList<,>) || Model.PropertyInfo.PropertyType.GetGenericTypeDefinition() == typeof(Dictionary<,>)) && Model.PropertyInfo.PropertyType.GetGenericArguments().First() == typeof(string):
-            <div class="@className checkLine">
-                @foreach (var subGroup in Model.SubFields)
-                {
-                    foreach (var subField in subGroup.Value)
+                case CmsAttributes.CmsTextEditorType.Auto when Model.PropertyInfo.PropertyType == typeof(bool):
+                    <div class="col col-6 checkLine">
+                        <div class="item" data-label-style="normal" data-label-width="0">
+                            <span class="inline">
+                                <label class="checkbox">
+                                    <input type="checkbox" value="@Model.Name" @(Model.Value != null && Model.Value.ToString() != "" && (bool)Model.Value ? "checked" : "") data-history-property="@Model.Name" disabled>
+                                    <span>@Model.PrettyName</span>
+                                </label>
+                            </span>
+                        </div>
+                    </div>
+                    RenderHtml(other);
+                    break;
+
+                case CmsAttributes.CmsTextEditorType.Auto when Model.PropertyInfo.PropertyType.IsGenericType && (Model.PropertyInfo.PropertyType.GetGenericTypeDefinition() == typeof(SortedList<,>) || Model.PropertyInfo.PropertyType.GetGenericTypeDefinition() == typeof(Dictionary<,>)) && Model.PropertyInfo.PropertyType.GetGenericArguments().First() == typeof(string):
+                    @foreach (var subGroup in Model.SubFields)
                     {
-                        <partial name="/Modules/Templates/Views/DynamicContent/Partials/HistoryInputGenerator.cshtml" model="subField" />
+                        for (var i = 0; i < subGroup.Value.Count; i++)
+                        {
+                            RenderHtml(subGroup.Value[i], other.SubFields[subGroup.Key][i]);
+                        }
                     }
-                }
-            </div>
-            break;
+                    break;
 
-        case CmsAttributes.CmsTextEditorType.Auto:
-            <div class="@className">
+                case CmsAttributes.CmsTextEditorType.Auto:
+                    <div class="col col-6">
+                        <div class="item" data-label-style="float" data-label-width="0">
+                            <span>No HTML Generated for "@Model.PrettyName". The type "@Model.PropertyInfo.PropertyType" was unknown to generator.</span>
+                        </div>
+                    </div>
+                    RenderHtml(other);
+                    break;
+
+                case CmsAttributes.CmsTextEditorType.TextBox:
+                    <div class="col col-6">
+                        <div class="item" data-label-style="float" data-label-width="0">
+                            <h4><label>@Model.PrettyName</label></h4>
+                            <span class="k-widget k-input k-state-default">
+                                <textarea class="textField k-input" autocomplete="off" data-history-property="@Model.Name" disabled>@Model.Value</textarea>
+                            </span>
+                        </div>
+                    </div>
+                    RenderHtml(other);
+                    break;
+
+                case CmsAttributes.CmsTextEditorType.QueryEditor:
+                    <div class="col col-12 diffField" data-type="Query" field-name="@Model.PrettyName">
+                        <span class="oldValue" value="@Model.Value">Old value placeholder</span>
+                        <span class="newValue" value="@other.Value">New value placeholder</span>
+                    </div>
+                    break;
+
+                case CmsAttributes.CmsTextEditorType.HtmlEditor:
+                    <div class="col col-12 diffField" data-type="Html" field-name="@Model.PrettyName">
+                        <span class="oldValue" value="@Model.Value">Old value placeholder</span>
+                        <span class="newValue" value="@other.Value">New value placeholder</span>
+                    </div>
+                    break;
+
+                case CmsAttributes.CmsTextEditorType.XmlEditor:
+                    <div class="col col-12 diffField" data-type="Xml" field-name="@Model.PrettyName">
+                        <span class="oldValue" value="@Model.Value">Old value placeholder</span>
+                        <span class="newValue" value="@other.Value">New value placeholder</span>
+                    </div>
+                    break;
+
+                case CmsAttributes.CmsTextEditorType.JsEditor:
+                    <div class="col col-12 diffField" data-type="JS" field-name="@Model.PrettyName">
+                        <span class="oldValue" value="@Model.Value">Old value placeholder</span>
+                        <span class="newValue" value="@other.Value">New value placeholder</span>
+                    </div>
+                    break;
+
+                case CmsAttributes.CmsTextEditorType.JsonEditor:
+                    <div class="col col-12 diffField" data-type="Json" field-name="@Model.PrettyName">
+                        <span class="oldValue" value="@Model.Value">Old value placeholder</span>
+                        <span class="newValue" value="@other.Value">New value placeholder</span>
+                    </div>
+                    break;
+
+                case CmsAttributes.CmsTextEditorType.TextEditor:
+                    <div class="col col-12 diffField" data-type="Text" field-name="@Model.PrettyName">
+                        <span class="oldValue" value="@Model.Value">Old value placeholder</span>
+                        <span class="newValue" value="@other.Value">New value placeholder</span>
+                    </div>
+                    break;
+
+                default:
+                    <div class="col col-12">
+                        <div class="item" data-label-style="float" data-label-width="0">
+                            <span>No HTML Generated for "@Model.PrettyName". The text editor type "@Model.CmsPropertyAttribute.TextEditorType" was unknown to generator.</span>
+                        </div>
+                    </div>
+                    break;
+            }
+        }
+        catch (Exception exception)
+        {
+            <div class="col col-12">
                 <div class="item" data-label-style="float" data-label-width="0">
-                    <span>No HTML Generated for "@Model.PrettyName". The type "@Model.PropertyInfo.PropertyType" was unknown to generator.</span>
+                    <span>@exception</span>
                 </div>
             </div>
-            break;
-
-        case CmsAttributes.CmsTextEditorType.TextBox:
-            <div class="@className">
-                <div class="item" data-label-style="float" data-label-width="0">
-                    <h4><label>@Model.PrettyName</label></h4>
-                    <span class="k-widget k-input k-state-default">
-                        <textarea class="textField k-input" autocomplete="off" data-history-property="@Model.Name" disabled>@Model.Value</textarea>
-                    </span>
-                </div>
-            </div>
-            break;
-
-        case CmsAttributes.CmsTextEditorType.QueryEditor:
-            <div class="@className">
-                <div class="item" data-label-style="float" data-label-width="0">
-                    <h4><label>@Model.PrettyName</label></h4>
-                    <span class="k-widget k-input k-state-default">
-                        <textarea data-history-property="@Model.Name" data-field-type="text/x-mysql" disabled>@Model.Value</textarea>
-                    </span>
-                </div>
-            </div>
-            break;
-
-        case CmsAttributes.CmsTextEditorType.HtmlEditor:
-            <div class="@className">
-                <div class="item" data-label-style="float" data-label-width="0">
-                    <h4><label>@Model.PrettyName</label></h4>
-                    <span class="k-widget k-input k-state-default">
-                        <textarea data-history-property="@Model.Name" data-field-type="text/html" disabled>@Model.Value</textarea>
-                    </span>
-                </div>
-            </div>
-            break;
-
-        case CmsAttributes.CmsTextEditorType.XmlEditor:
-            <div class="@className">
-                <div class="item" data-label-style="float" data-label-width="0">
-                    <h4><label>@Model.PrettyName</label></h4>
-                    <span class="k-widget k-input k-state-default">
-                        <textarea data-history-property="@Model.Name" data-field-type="application/xml" disabled>@Model.Value</textarea>
-                    </span>
-                </div>
-            </div>
-            break;
-
-        case CmsAttributes.CmsTextEditorType.JsEditor:
-            <div class="@className">
-                <div class="item" data-label-style="float" data-label-width="0">
-                    <h4><label>@Model.PrettyName</label></h4>
-                    <span class="k-widget k-input k-state-default">
-                        <textarea data-history-property="@Model.Name" data-field-type="text/javascript" disabled>@Model.Value</textarea>
-                    </span>
-                </div>
-            </div>
-            break;
-
-        case CmsAttributes.CmsTextEditorType.JsonEditor:
-            <div class="@className">
-                <div class="item" data-label-style="float" data-label-width="0">
-                    <h4><label>@Model.PrettyName</label></h4>
-                    <span class="k-widget k-input k-state-default">
-                        <textarea data-history-property="@Model.Name" data-field-type="application/json" disabled>@Model.Value</textarea>
-                    </span>
-                </div>
-            </div>
-            break;
-
-        case CmsAttributes.CmsTextEditorType.TextEditor:
-            <div class="@className">
-                <div class="item" data-label-style="float" data-label-width="0">
-                    <h4><label>@Model.PrettyName</label></h4>
-                    <span class="k-widget k-input k-state-default">
-                        <textarea data-history-property="@Model.Name" data-field-type="text" disabled>@Model.Value</textarea>
-                    </span>
-                </div>
-            </div>
-            break;
-
-        default:
-            <div class="@className">
-                <div class="item" data-label-style="float" data-label-width="0">
-                    <span>No HTML Generated for "@Model.PrettyName". The text editor type "@Model.CmsPropertyAttribute.TextEditorType" was unknown to generator.</span>
-                </div>
-            </div>
-            break;
+        }
     }
-}
-catch (Exception exception)
-{
-    <div class="@className">
-        <div class="item" data-label-style="float" data-label-width="0">
-            <span>@exception</span>
-        </div>
-    </div>
 }

--- a/FrontEnd/Modules/Templates/Views/DynamicContent/Partials/HistoryInputGenerator.cshtml
+++ b/FrontEnd/Modules/Templates/Views/DynamicContent/Partials/HistoryInputGenerator.cshtml
@@ -1,7 +1,6 @@
 ﻿@using GeeksCoreLibrary.Core.Cms.Attributes
 @using Api.Core.Helpers
 @using FrontEnd.Modules.Templates.Models
-@* @model FrontEnd.Modules.Templates.Models.FieldViewModel *@
 @model (FrontEnd.Modules.Templates.Models.FieldViewModel oldVersion, FrontEnd.Modules.Templates.Models.FieldViewModel newVersion)
 
 @{ RenderHtml(Model.oldVersion, Model.newVersion); }

--- a/FrontEnd/Modules/Templates/Views/Templates/Partials/HistoryTabRows.cshtml
+++ b/FrontEnd/Modules/Templates/Views/Templates/Partials/HistoryTabRows.cshtml
@@ -1,4 +1,5 @@
 @using FrontEnd.Modules.Templates.Models
+@using GeeksCoreLibrary.Modules.Templates.Enums
 @model HistoryTabViewModel
 @{
     var publishLogCounter = 0;
@@ -12,8 +13,8 @@
         {
             <div class="row historyLine">
                 <div class="col col-12 historyTagline">
-                    <span><span class="k-icon k-i-edit"></span> Published Environment |</span>
-                    <span><span class="k-icon k-i-calendar"></span> @Model.PublishHistory[i].GetDisplayChangedOn() |</span>
+                    <span><span class="k-icon k-i-edit"></span> <b>Published Environment</b> | </span>
+                    <span><span class="k-icon k-i-calendar"></span> @Model.PublishHistory[i].GetDisplayChangedOn() | </span>
                     <span><span class="k-icon k-i-user"></span> door @Model.PublishHistory[i].ChangedBy </span>
                 </div>
                 @if (Model.PublishHistory[i].PublishLog.OldLive != Model.PublishHistory[i].PublishLog.NewLive)
@@ -104,13 +105,13 @@
             {
                 <ins class="version test" title="test"></ins>
             }
-            <span><span class="k-icon k-i-edit"></span> Versie @historyModel.Version |</span>
-            <span><span class="k-icon k-i-calendar"></span> @historyModel.GetDisplayChangedOn() |</span>
+            <span><span class="k-icon k-i-edit"></span> <b>Versie @historyModel.Version</b> | </span>
+            <span><span class="k-icon k-i-calendar"></span> @historyModel.GetDisplayChangedOn() | </span>
             <span><span class="k-icon k-i-user"></span> door @historyModel.ChangedBy </span>
         </div>
         @foreach (var change in historyModel.TemplateChanges)
         {
-            if (change.Value.Key is bool booleanNewValue && change.Value.Value is bool booleanOldValue)
+            if (change.Value.Item1 is bool booleanNewValue && change.Value.Item2 is bool booleanOldValue)
             {
                 <div class="col col-6 checkLine">
                     <div class="item" data-label-style="normal" data-label-width="0">
@@ -149,6 +150,13 @@
                     </div>
                 </div>
             }
+            else if (change.Value.Item3 is TemplateTypes.Html or TemplateTypes.Query or TemplateTypes.Js or TemplateTypes.Css or TemplateTypes.Scss or TemplateTypes.Xml)
+            {
+                <div class="col col-12 diffField" data-type="@change.Value.Item3" field-name="@change.Key">
+                    <span class="oldValue" value="@change.Value.Item2">Old value placeholder</span>
+                    <span class="newValue" value="@change.Value.Item1">New value placeholder</span>
+                </div>
+            }
             else
             {
                 <div class="col col-6">
@@ -156,14 +164,7 @@
                         <span class="handler">&nbsp;</span>
                         <h4><label for="@change.Key">@change.Key</label></h4>
                         <span class="k-widget k-input k-state-default">
-                            @if (String.Equals(change.Key, "editorValue"))
-                            {
-                                <textarea id="text_101" autocomplete="off" disabled>@change.Value.Value</textarea>
-                            }
-                            else
-                            {
-                                <input type="text" id="text_101" class="textField k-input" autocomplete="off" value="@change.Value.Value" disabled/>
-                            }
+                            <input type="text" id="text_101" class="textField k-input" autocomplete="off" value="@change.Value.Item2" disabled/>
                         </span>
                     </div>
                 </div>
@@ -173,14 +174,7 @@
                         <span class="handler">&nbsp;</span>
                         <h4><label for="text_102">@change.Key</label></h4>
                         <span class="k-widget k-input k-state-default">
-                            @if (String.Equals(change.Key, "editorValue"))
-                            {
-                                <textarea id="text_102" autocomplete="off" disabled>@change.Value.Key</textarea>
-                            }
-                            else
-                            {
-                                <input type="text" id="text_102" class="textField k-input" autocomplete="off" value="@change.Value.Key" disabled />
-                            }
+                            <input type="text" id="text_102" class="textField k-input" autocomplete="off" value="@change.Value.Item1" disabled />
                         </span>
                     </div>
                 </div>
@@ -201,7 +195,7 @@
                         <span class="handler">&nbsp;</span>
                         <span class="inline">
                             <label class="checkbox">
-                                @if ((Boolean)change.Value.Value)
+                                @if ((Boolean)change.Value.Item2)
                                 {
                                     <input id="change.Key" name="change.Key" type="checkbox" checked="checked" disabled>
                                 }
@@ -219,7 +213,7 @@
                         <span class="handler">&nbsp;</span>
                         <span class="inline">
                             <label class="checkbox">
-                                @if ((Boolean)change.Value.Key)
+                                @if ((Boolean)change.Value.Item1)
                                 {
                                     <input id="@change.Key" name="@change.Key" type="checkbox" checked="checked" disabled>
                                 }
@@ -236,28 +230,26 @@
         }
         @if (historyModel.DynamicContentChanges.Count > 0)
         {
-            <div class="row historyLine">
+            <div class="row historyLine historyDynamic">
                 <div class="col col-12 historyTagline">
-                    <span>Dynamic Content:</span>
+                    <span><b>Versie @historyModel.Version</b> dynamische content:</span>
                 </div>
-            </div>
-
-            @foreach (var dynamicHistory in historyModel.DynamicContentChanges)
-            {
-                <div class="col col-12 historyTagline">
-                    <span><span class="k-icon k-i-edit"></span> Versie @dynamicHistory.Version |</span>
-                    <span><span class="k-icon k-i-calendar"></span> @dynamicHistory.GetDisplayChangedOn() |</span>
-                    <span><span class="k-icon k-i-user"></span> door @dynamicHistory.ChangedBy </span>
-                </div>
-                @if (dynamicHistory.ChangedFields != null)
+                @foreach (var dynamicHistory in historyModel.DynamicContentChanges)
                 {
-                    @foreach (var (oldVersion, newVersion) in dynamicHistory.ChangedFields)
+                    <div class="col col-12 historyTagline">
+                        <span><span class="k-icon k-i-edit"></span> @dynamicHistory.Name (@dynamicHistory.Component) | Versie @dynamicHistory.Version | </span>
+                        <span><span class="k-icon k-i-calendar"></span> @dynamicHistory.GetDisplayChangedOn() | </span>
+                        <span><span class="k-icon k-i-user"></span> door @dynamicHistory.ChangedBy </span>
+                    </div>
+                    @if (dynamicHistory.ChangedFields != null)
                     {
-                        <partial name="/Modules/Templates/Views/DynamicContent/Partials/HistoryInputGenerator.cshtml" model="oldVersion" />
-                        <partial name="/Modules/Templates/Views/DynamicContent/Partials/HistoryInputGenerator.cshtml" model="newVersion" />
+                        @foreach (var pair in dynamicHistory.ChangedFields)
+                        {
+                            <partial name="/Modules/Templates/Views/DynamicContent/Partials/HistoryInputGenerator.cshtml" model="pair" />
+                        }
                     }
                 }
-            }
+            </div>
         }
     </div>
 }

--- a/FrontEnd/package-lock.json
+++ b/FrontEnd/package-lock.json
@@ -21,6 +21,8 @@
         "codemirror": "^5.65.10",
         "codemirror-lint-eslint": "^1.0.1",
         "csslint": "^1.0.5",
+        "diff": "^5.1.0",
+        "diff2html": "^3.4.45",
         "jshint": "^2.13.6",
         "jszip": "^3.10.1",
         "luxon": "^3.3.0",
@@ -1633,6 +1635,29 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff2html": {
+      "version": "3.4.45",
+      "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-3.4.45.tgz",
+      "integrity": "sha512-1SxsjYZYbxX0GGMYJJM7gM0SpMSHqzvvG0UJVROCDpz4tylH2T+EGiinm2boDmTrMlLueVxGfKNxGNLZ9zDlkQ==",
+      "dependencies": {
+        "diff": "5.1.0",
+        "hogan.js": "3.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "highlight.js": "11.8.0"
+      }
+    },
     "node_modules/diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -2312,6 +2337,15 @@
         "he": "bin/he"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.8.0.tgz",
+      "integrity": "sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -2320,6 +2354,32 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/hogan.js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
+      "integrity": "sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==",
+      "dependencies": {
+        "mkdirp": "0.3.0",
+        "nopt": "1.0.10"
+      },
+      "bin": {
+        "hulk": "bin/hulk"
+      }
+    },
+    "node_modules/hogan.js/node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/html-minifier-terser": {
@@ -3155,6 +3215,15 @@
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+      "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "engines": {
         "node": "*"
       }

--- a/FrontEnd/package.json
+++ b/FrontEnd/package.json
@@ -20,6 +20,8 @@
     "codemirror": "^5.65.10",
     "codemirror-lint-eslint": "^1.0.1",
     "csslint": "^1.0.5",
+    "diff": "^5.1.0",
+    "diff2html": "^3.4.45",
     "jshint": "^2.13.6",
     "jszip": "^3.10.1",
     "luxon": "^3.3.0",


### PR DESCRIPTION
Added JS to render Diff2Html fields instead of the big text areas (for HTML, queries, etc) in the Template and Dynamic Content history tabs. Adjusted the way the HTML is generated for those tabs to simplify the JS code.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205766552804799