### PR TITLE
Add friendly validation message for pattern and step

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
@@ -541,6 +541,14 @@ const moduleSettings = {
                     required: (input) => {
                         const fieldDisplayName = $(input).closest(".item").find("> h4 > label").text() || $(input).attr("name");
                         return `${fieldDisplayName} is verplicht`;
+                    },
+                    pattern: (input) => {
+                        const fieldDisplayName = $(input).closest(".item").find("> h4 > label").text() || $(input).attr("name");
+                        return `${fieldDisplayName} is niet correct`;
+                    },
+                    step: (input) => {
+                        const fieldDisplayName = $(input).closest(".item").find("> h4 > label").text() || $(input).attr("name");
+                        return `${fieldDisplayName} is niet correct`;
                     }
                 }
             }).data("kendoValidator");

--- a/FrontEnd/Modules/DynamicItems/Scripts/Windows.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Windows.js
@@ -326,6 +326,14 @@ export class Windows {
                     required: (input) => {
                         const fieldDisplayName = $(input).closest(".item").find("> h4 > label").text() || $(input).attr("name");
                         return `${fieldDisplayName} is verplicht`;
+                    },
+                    pattern: (input) => {
+                        const fieldDisplayName = $(input).closest(".item").find("> h4 > label").text() || $(input).attr("name");
+                        return `${fieldDisplayName} is niet correct`;
+                    },
+                    step: (input) => {
+                        const fieldDisplayName = $(input).closest(".item").find("> h4 > label").text() || $(input).attr("name");
+                        return `${fieldDisplayName} is niet correct`;
                     }
                 }
             }).data("kendoValidator");


### PR DESCRIPTION
Kendo has built in formats for validation errors.

In this case the format was '{0} is not correct' where {0} is the name of the attribute, which is a non-friendly naming. 
I have added custom validation for the attributes which use the name of the attribute as parameter and take the label text instead. 


Ticket:  https://app.asana.com/0/1201027711166952/1205957824190022/f