### PR TITLE
bugfix: parent_id is not ued when adding items with a subentity grid

### DIFF
--- a/Api/Modules/Items/Services/ItemsService.cs
+++ b/Api/Modules/Items/Services/ItemsService.cs
@@ -669,9 +669,16 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
             try
             {
                 await clientDatabaseConnection.BeginTransactionAsync();
-                var newItem = await wiserItemsService.CreateAsync(item, userId: userId, username: username, encryptionKey: encryptionKey, createNewTransaction: false);
+                //Get the information for the link (must the item be connected via ParentItemId?)
+                var linkTypeSettings = await wiserItemsService.GetLinkTypeSettingsAsync(linkType:linkType, sourceEntityType: item.EntityType);
 
-                result.NewLinkId = await wiserItemsService.AddItemLinkAsync(newItem.Id, parentId, linkType, userId: userId, username: username, skipPermissionsCheck: true);
+                //Create the new item
+                var newItem = await wiserItemsService.CreateAsync(item, parentId:(linkTypeSettings.UseItemParentId ? parentId : null) ,userId: userId, username: username, encryptionKey: encryptionKey, createNewTransaction: false);
+
+                //Add the link to the parent if not connected via ParentItemId
+                if (!linkTypeSettings.UseItemParentId)
+                    result.NewLinkId = await wiserItemsService.AddItemLinkAsync(newItem.Id, parentId, linkType, userId: userId, username: username, skipPermissionsCheck: true);
+                
                 result.NewItemId = newItem.EncryptedId;
                 result.NewItemIdPlain = newItem.Id;
 

--- a/Api/Modules/Items/Services/ItemsService.cs
+++ b/Api/Modules/Items/Services/ItemsService.cs
@@ -669,15 +669,9 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
             try
             {
                 await clientDatabaseConnection.BeginTransactionAsync();
-                //Get the information for the link (must the item be connected via ParentItemId?)
-                var linkTypeSettings = await wiserItemsService.GetLinkTypeSettingsAsync(linkType:linkType, sourceEntityType: item.EntityType);
 
-                //Create the new item
-                var newItem = await wiserItemsService.CreateAsync(item, parentId:(linkTypeSettings.UseItemParentId ? parentId : null) ,userId: userId, username: username, encryptionKey: encryptionKey, createNewTransaction: false);
-
-                //Add the link to the parent if not connected via ParentItemId
-                if (!linkTypeSettings.UseItemParentId)
-                    result.NewLinkId = await wiserItemsService.AddItemLinkAsync(newItem.Id, parentId, linkType, userId: userId, username: username, skipPermissionsCheck: true);
+                //Create the new item (with the link)
+                var newItem = await wiserItemsService.CreateAsync(item, parentId ,userId: userId, username: username, encryptionKey: encryptionKey, createNewTransaction: false, linkTypeNumber:linkType);
                 
                 result.NewItemId = newItem.EncryptedId;
                 result.NewItemIdPlain = newItem.Id;


### PR DESCRIPTION
I a sub entity grid (or grid) is used and the entity to be added must be connected via the parent_item_id of wiser_item this did not work. There was still a link added to the wiser_itemlink table and the parent_item_id was still set to 0 for the new item. This behaviour is fixed in this release.