### PR TITLE
Remove unknown variables from file names

### DIFF
--- a/FrontEnd/Modules/Base/Scripts/Utils.js
+++ b/FrontEnd/Modules/Base/Scripts/Utils.js
@@ -527,9 +527,10 @@ export class Wiser {
      * @param {string} input The input string to do the replacements on.
      * @param {any} itemDetails The details (fields/properties + values) of an item.
      * @param {boolean} uriEncodeValues Whether or not to encode all values to be safely used in an URL.
+     * @param {boolean} removeUnknownVariables Whether or not to remove all variables that are not found in the data object.
      * @returns {string} The input string with all variables replaced with values from fields.
      */
-    static doWiserItemReplacements(input, itemDetails, uriEncodeValues = false) {
+    static doWiserItemReplacements(input, itemDetails, uriEncodeValues = false, removeUnknownVariables = false) {
         if (!input || typeof input !== "string") {
             return input;
         }
@@ -548,7 +549,7 @@ export class Wiser {
             }
         }
 
-        return Wiser.doObjectReplacements(output, itemDetails.property_, uriEncodeValues);
+        return Wiser.doObjectReplacements(output, itemDetails.property_, uriEncodeValues, removeUnknownVariables);
     }
 
     /**
@@ -556,9 +557,10 @@ export class Wiser {
      * @param {string} input The input string to do the replacements on.
      * @param {any} data An JSON object with keys and values to use for replacements.
      * @param {boolean} uriEncodeValues Whether or not to encode all values to be safely used in an URL.
+     * @param {boolean} removeUnknownVariables Whether or not to remove all variables that are not found in the data object.
      * @returns {any} The input string with all variables replaced with values from the object.
      */
-    static doObjectReplacements(input, data, uriEncodeValues = false) {
+    static doObjectReplacements(input, data, uriEncodeValues = false, removeUnknownVariables = false) {
         if (!data) {
             return input;
         }
@@ -585,7 +587,24 @@ export class Wiser {
             output = output.replace(regExp, value);
         }
 
+        if (removeUnknownVariables) {
+            output = Wiser.removeUnknownVariables(output);
+        }
+
         return Strings.convertToNumberIfPossible(output);
+    }
+
+    /**
+     * A method to remove all variables from a string.
+     * @param input The string to remove the variables from.
+     * @returns {*} The input string without any variables.
+     */
+    static removeUnknownVariables(input) {
+        if (!input) {
+            return input;
+        }
+
+        return input.replace(/{[a-zA-Z0-9]+[\?a-zA-Z0-9]*}/gi, "");
     }
 
     /**
@@ -888,7 +907,7 @@ export class Wiser {
 
         extraHeaders.Authorization = `${Strings.capitalizeFirst(authenticationData.tokenType)} ${authenticationData.accessToken}`;
     }
-    
+
     static fileManagerModes = Object.freeze({
         images: "images",
         files: "files",
@@ -910,11 +929,11 @@ export class Wiser {
             const fileManagerWindowSender = { kendoEditor: kendoEditor, codeMirror: null, contentbuilder: null };
             const fileManagerWindowMode = this.fileManagerModes.files;
             const fileManagerWindow = Wiser.initializeFileManager(fileManagerWindowSender, fileManagerWindowMode, null, null, moduleName);
-            
+
             fileManagerWindow.center().open();
         }
     }
-    
+
     /**
      * Event that gets called when the user executes the custom action for adding an image from Wiser to the HTML editor.
      * This will open the fileHandler from Wiser 1.0 via the parent frame. Therefor this function only works while Wiser is being loaded in an iframe.
@@ -929,12 +948,12 @@ export class Wiser {
         } else {
             const fileManagerWindowSender = { kendoEditor: kendoEditor, codeMirror: null, contentbuilder: null };
             const fileManagerWindowMode = this.fileManagerModes.images;
-            
+
             const fileManagerWindow = Wiser.initializeFileManager(fileManagerWindowSender, fileManagerWindowMode, null, null, moduleName);
             fileManagerWindow.center().open();
         }
     }
-    
+
     /**
      * Event that gets called when the user executes the custom action for entering a translation variable.
      * @param {any} event The event from the execute action.
@@ -1256,7 +1275,7 @@ export class Wiser {
                 if (fileManagerWindowSender && fileManagerWindowSender.kendoEditor) {
                     selectedText = fileManagerWindowSender.kendoEditor.getSelection().toString();
                 }
-                
+
                 fileManagerIframe.src = `/Modules/FileManager?mode=${fileManagerWindowMode}&iframe=true&selectedText=${encodeURIComponent(selectedText)}`;
 
                 switch (fileManagerWindowMode) {
@@ -1369,7 +1388,7 @@ export class Wiser {
         if (iframeMode || gridviewMode) {
             return;
         }
-        
+
         /***** NOTE: Only add code below this line that should NOT be executed if the module is loaded inside an iframe *****/
         const mainWindow = $("#window").kendoWindow({
             title: moduleName || "Modulenaam",

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -2508,7 +2508,11 @@ export class Fields {
                             };
 
                             if (currentAction.pdfFilename) {
-                                pdfToHtmlData.fileName = Wiser.doWiserItemReplacements(currentAction.pdfFilename, currentItemDetails);
+                                pdfToHtmlData.fileName = Wiser.doWiserItemReplacements(currentAction.pdfFilename, currentItemDetails, false, true);
+                            }
+
+                            if (!pdfToHtmlData.fileName || pdfToHtmlData.fileName.startsWith(".pdf")) {
+                                pdfToHtmlData.fileName = "Document.pdf";
                             }
 
                             pdfToHtmlData.documentOptions = "";
@@ -2626,7 +2630,11 @@ export class Fields {
                                                     };
 
                                                     if (currentAction.pdfFilename) {
-                                                        pdfToHtmlData.fileName = Wiser.doWiserItemReplacements(currentAction.pdfFilename, currentItemDetails);
+                                                        pdfToHtmlData.fileName = Wiser.doWiserItemReplacements(currentAction.pdfFilename, currentItemDetails, false, true);
+                                                    }
+
+                                                    if (!pdfToHtmlData.fileName || pdfToHtmlData.fileName.startsWith(".pdf")) {
+                                                        pdfToHtmlData.fileName = "Document.pdf";
                                                     }
 
                                                     let ajaxOptions = {
@@ -2863,10 +2871,10 @@ export class Fields {
         } else {
              this.base.windows.fileManagerWindowSender = { kendoEditor: kendoEditor, codeMirror: codeMirror, contentbuilder: contentbuilder };
              this.base.windows.fileManagerWindowMode = this.base.windows.fileManagerModes.images;
-             const fileManagerWindow = Wiser.initializeFileManager(this.base.windows.fileManagerWindowSender, 
-                 this.base.windows.fileManagerWindowMode, this.base.settings.iframeMode, 
+             const fileManagerWindow = Wiser.initializeFileManager(this.base.windows.fileManagerWindowSender,
+                 this.base.windows.fileManagerWindowMode, this.base.settings.iframeMode,
                  this.base.settings.gridViewMode, this.base.settings.moduleName);
-             
+
              fileManagerWindow.center().open();
         }
     }
@@ -2885,10 +2893,10 @@ export class Fields {
         } else {
             this.base.windows.fileManagerWindowSender = { kendoEditor: kendoEditor, codeMirror: codeMirror, contentbuilder: contentbuilder };
             this.base.windows.fileManagerWindowMode = this.base.windows.fileManagerModes.files;
-            const fileManagerWindow = Wiser.initializeFileManager(this.base.windows.fileManagerWindowSender, 
-                this.base.windows.fileManagerWindowMode, this.base.settings.iframeMode, 
+            const fileManagerWindow = Wiser.initializeFileManager(this.base.windows.fileManagerWindowSender,
+                this.base.windows.fileManagerWindowMode, this.base.settings.iframeMode,
                 this.base.settings.gridViewMode, this.base.settings.moduleName);
-            
+
             fileManagerWindow.center().open();
         }
     }
@@ -2908,7 +2916,7 @@ export class Fields {
             this.base.windows.fileManagerWindowSender = { kendoEditor: kendoEditor, codeMirror: codeMirror, contentbuilder: contentbuilder };
             this.base.windows.fileManagerWindowMode = this.base.windows.fileManagerModes.templates;
             const fileManagerWindow = Wiser.initializeFileManager(this.base.windows.fileManagerWindowSender, this.base.windows.fileManagerWindowMode, this.base.settings.iframeMode, this.base.settings.gridViewMode, this.base.settings.moduleName);
-            
+
             fileManagerWindow.center().open();
         }
     }


### PR DESCRIPTION
When downloading or e-mailing files via Wiser, we can have variables in the file name. We now remove those variables from the file name, if we can't find a property for them.

Asana ticket: https://app.asana.com/0/1182779092805226/1204636198695342