### PR TITLE
subgrid toolbar whitespace when count is hidden is wrong

### DIFF
--- a/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
+++ b/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
@@ -289,6 +289,13 @@ async function generateGrid(data, model, columns) {
             text: "",
             template: '<div class="counterContainer"><span class="counter">0</span> <span class="plural">resultaten</span><span class="singular" style="display: none;">resultaat</span></div>'
         });
+    } else {
+        toolbar.push({
+            name: "whitespace",
+            iconClass: "",
+            text: "",
+            template: '<div class="counterContainer"></div>'
+        });
     }
 
     if (!readonly && (!options.toolbar || !options.toolbar.hideCreateButton)) {

--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -309,6 +309,13 @@ export class Grids {
                     text: "",
                     template: `<div class="counterContainer"><span class="counter">0</span> <span class="plural">resultaten</span><span class="singular" style="display: none;">resultaat</span></div>`
                 });
+            } else {
+                toolbar.push({
+                    name: "whitespace",
+                    iconClass: "",
+                    text: "",
+                    template: `<div class="counterContainer"></div>`
+                });
             }
 
             if (!gridViewSettings.toolbar || !gridViewSettings.toolbar.hideExportButton) {


### PR DESCRIPTION
Not having the counterContainer div means there is nothing pushing the buttons to the right side of the toolbar. Adding the div but keeping it empty is the most stable way of achieving the desired outcome.

https://app.asana.com/0/1201027711166952/1205657687817938