### PR TITLE
Bugfix/version publish to branch

### DIFF
--- a/Api/Modules/Templates/Services/TemplatesService.cs
+++ b/Api/Modules/Templates/Services/TemplatesService.cs
@@ -1454,7 +1454,11 @@ LIMIT 1";
                 }
 
                 // Create a new version of the template, so that any changes made after this will be done in the new version instead of the published one.
-                await CreateNewVersionAsync(template.TemplateId, version);
+                // Does not apply if the template was published to live within a branch.
+                if (String.IsNullOrWhiteSpace(branchDatabaseName))
+                {
+                    await CreateNewVersionAsync(template.TemplateId, version);
+                }
             }
 
             var newPublished = PublishedEnvironmentHelper.CalculateEnvironmentsToPublish(currentPublished, version, environment);


### PR DESCRIPTION
When a template was being pushed to a branch a new version was always created. When this version was then deployed to live from the template module an older version was left as dirty and thus showing up in the version control.

No ticket.