### PR TITLE
Removed thousands separator in numeric fields

### DIFF
--- a/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
+++ b/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
@@ -228,7 +228,7 @@ const moduleSettings = {
                 const isDecimal = $(element).data("decimal") === true;
                 $(element).kendoNumericTextBox({
                     decimals: isDecimal ? 2 : 0,
-                    format: isDecimal ? "n2" : "n0",
+                    format: isDecimal ? "n2" : "#",
                     change: () => this.onInputChange(true),
                     spin: () => this.onInputChange(false)
                 });


### PR DESCRIPTION
Changed number formatting for all dynamic content numeric fields to be a plain number, without a thousands separator.

https://app.asana.com/0/1201027711166952/1206116303028431