### PR TITLE
Removed temporary table update methods

### DIFF
--- a/Api/Modules/Dashboard/Services/DashboardService.cs
+++ b/Api/Modules/Dashboard/Services/DashboardService.cs
@@ -17,9 +17,7 @@ using Api.Modules.TaskAlerts.Interfaces;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
-using GeeksCoreLibrary.Modules.Databases.Models;
 using GeeksCoreLibrary.Modules.WiserDashboard.Models;
-using MySqlConnector;
 using Newtonsoft.Json.Linq;
 
 namespace Api.Modules.Dashboard.Services;
@@ -101,7 +99,6 @@ public class DashboardService : IDashboardService, IScopedService
         }
 
         // Make sure the tables exist.
-        await KeepTablesUpToDateAsync(databaseName);
         await CheckAndUpdateTablesAsync(databaseName);
         await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
 
@@ -497,10 +494,7 @@ ORDER BY time_active DESC";
         foreach (var item in openTaskAlerts.ModelObject)
         {
             // Initialize result for a user if it's not added yet.
-            if (!result.ContainsKey(item.UserName))
-            {
-                result[item.UserName] = 0;
-            }
+            result.TryAdd(item.UserName, 0);
 
             // Simply add one for the current user.
             result[item.UserName]++;
@@ -597,9 +591,7 @@ ORDER BY time_active DESC";
     /// <param name="databaseName">The name of the database that is currently being worked in (for the branches functionality).</param>
     private async Task CheckAndUpdateTablesAsync(string databaseName = null)
     {
-        await databaseHelpersService.CheckAndUpdateTablesAsync(new List<string>
-        {
-            // Ensure entities table has the "show_in_dashboard" column.
+        await databaseHelpersService.CheckAndUpdateTablesAsync([
             WiserTableNames.WiserEntity,
             // Ensure data selector table has the "show_in_dashboard" column.
             WiserTableNames.WiserDataSelector,
@@ -607,7 +599,7 @@ ORDER BY time_active DESC";
             WiserTableNames.WiserDashboard,
             // For the user login data.
             WiserTableNames.WiserLoginLog
-        }, databaseName);
+        ], databaseName);
     }
 
     /// <summary>
@@ -650,11 +642,10 @@ ORDER BY time_active DESC";
     /// <inheritdoc />
     public async Task<ServiceResult<List<Service>>> GetWtsServicesAsync(ClaimsIdentity identity)
     {
-        await databaseHelpersService.CheckAndUpdateTablesAsync(new List<string>()
-        {
+        await databaseHelpersService.CheckAndUpdateTablesAsync([
             WiserTableNames.WtsLogs,
             WiserTableNames.WtsServices
-        });
+        ]);
 
         var services = new List<Service>();
 
@@ -839,69 +830,5 @@ WHERE id = ?serviceId");
 
         // Simply return the data selector service's result, as it's exactly the same type.
         return await dataSelectorsService.GetDataSelectorResultAsJsonAsync(identity, dataSelectorId, false, null, true);
-    }
-
-    /// <summary>
-    /// Checks if the MySQL tables for the dashboard is up-to-date.
-    /// </summary>
-    private async Task KeepTablesUpToDateAsync(string databaseName)
-    {
-        var lastTableUpdates = await databaseHelpersService.GetLastTableUpdatesAsync(databaseName);
-
-        // Check if the dashboard table needs to be updated.
-        if (!await databaseHelpersService.TableExistsAsync(WiserTableNames.WiserDashboard) || (lastTableUpdates.TryGetValue(WiserTableNames.WiserDashboard, out var value) && value >= new DateTime(2023, 2, 23)))
-        {
-            return;
-        }
-
-        // Add columns.
-        var column = new ColumnSettingsModel("user_login_active_top10", MySqlDbType.Int64, notNull: true, defaultValue: "0");
-        await databaseHelpersService.AddColumnToTableAsync(WiserTableNames.WiserDashboard, column, false, databaseName);
-        column = new ColumnSettingsModel("user_login_active_other", MySqlDbType.Int64, notNull: true, defaultValue: "0");
-        await databaseHelpersService.AddColumnToTableAsync(WiserTableNames.WiserDashboard, column, false, databaseName);
-
-        // Convert and drop the "user_login_time_top10" column if it still exists.
-        if (await databaseHelpersService.ColumnExistsAsync(WiserTableNames.WiserDashboard, "user_login_time_top10", databaseName))
-        {
-            await ConvertTimeSpanToSecondsAsync(WiserTableNames.WiserDashboard, databaseName, "user_login_time_top10", "user_login_active_top10");
-            await databaseHelpersService.DropColumnAsync(WiserTableNames.WiserDashboard, "user_login_time_top10", databaseName);
-        }
-
-        // Convert and drop the "user_login_time_other" column if it still exists.
-        if (await databaseHelpersService.ColumnExistsAsync(WiserTableNames.WiserDashboard, "user_login_time_other", databaseName))
-        {
-            await ConvertTimeSpanToSecondsAsync(WiserTableNames.WiserDashboard, databaseName, "user_login_time_other", "user_login_active_other");
-            await databaseHelpersService.DropColumnAsync(WiserTableNames.WiserDashboard, "user_login_time_other", databaseName);
-        }
-
-        clientDatabaseConnection.ClearParameters();
-        clientDatabaseConnection.AddParameter("tableName", WiserTableNames.WiserDashboard);
-        clientDatabaseConnection.AddParameter("lastUpdate", DateTime.Now);
-        var lastUpdateData = await clientDatabaseConnection.GetAsync($"SELECT `name` FROM `{WiserTableNames.WiserTableChanges}` WHERE `name` = ?tableName");
-        var queryDatabasePart = !String.IsNullOrWhiteSpace(databaseName) ? $"`{databaseName}`." : String.Empty;
-        if (lastUpdateData.Rows.Count == 0)
-        {
-            await clientDatabaseConnection.ExecuteAsync($"INSERT INTO {queryDatabasePart}`{WiserTableNames.WiserTableChanges}` (`name`, last_update) VALUES (?tableName, ?lastUpdate)");
-        }
-        else
-        {
-            await clientDatabaseConnection.ExecuteAsync($"UPDATE {queryDatabasePart}`{WiserTableNames.WiserTableChanges}` SET last_update = ?lastUpdate WHERE `name` = ?tableName LIMIT 1");
-        }
-    }
-
-    private async Task ConvertTimeSpanToSecondsAsync(string tableName, string databaseName, string oldColumnName, string newColumnName)
-    {
-        var queryDatabasePart = !String.IsNullOrWhiteSpace(databaseName) ? $"`{databaseName}`." : String.Empty;
-
-        var convertDataTable = await clientDatabaseConnection.GetAsync($"SELECT id, `{oldColumnName}` FROM {queryDatabasePart}`{tableName}`");
-        foreach (var dataRow in convertDataTable.Rows.Cast<DataRow>())
-        {
-            var seconds = Convert.ToInt32(Math.Floor(dataRow.Field<TimeSpan>(oldColumnName).TotalSeconds));
-
-            clientDatabaseConnection.ClearParameters();
-            clientDatabaseConnection.AddParameter("tableId", Convert.ToUInt64(dataRow["id"]));
-            clientDatabaseConnection.AddParameter("seconds", seconds);
-            await clientDatabaseConnection.ExecuteAsync($"UPDATE `{tableName}` SET `{newColumnName}` = ?seconds WHERE id = ?tableId");
-        }
     }
 }

--- a/Api/Modules/Tenants/Services/UsersService.cs
+++ b/Api/Modules/Tenants/Services/UsersService.cs
@@ -20,11 +20,9 @@ using GeeksCoreLibrary.Core.Interfaces;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Communication.Interfaces;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
-using GeeksCoreLibrary.Modules.Databases.Models;
 using Google.Authenticator;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using MySqlConnector;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using StringHelpers = Api.Core.Helpers.StringHelpers;
@@ -261,10 +259,10 @@ ORDER BY username.`value` ASC";
             clientDatabaseConnection.AddParameter("now", DateTime.Now);
 
             var query = $@"SELECT 
-	                        user.id, 
-	                        IFNULL(NULLIF(user.title, ''), username.value) AS name, 
-	                        username.`value` AS username, 
-	                        password.`value` AS password,
+                            user.id, 
+                            IFNULL(NULLIF(user.title, ''), username.value) AS name, 
+                            username.`value` AS username, 
+                            password.`value` AS password,
                             last_login_ip.value AS last_login_ip,
                             IF(last_login_date.value IS NULL, ?now, STR_TO_DATE(last_login_date.value, '%Y-%m-%d %H:%i:%s')) AS last_login_date,
                             IFNULL(require_password_change.value, '0') AS require_password_change,
@@ -961,8 +959,7 @@ ORDER BY username.`value` ASC";
                 await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
 
                 // Make sure the WiserLoginLog exists and is up-to-date.
-                await KeepTablesUpToDateAsync(clientDatabaseConnection.ConnectedDatabaseForWriting ?? clientDatabaseConnection.ConnectedDatabase);
-                await databaseHelpersService.CheckAndUpdateTablesAsync(new List<string> {WiserTableNames.WiserLoginLog});
+                await databaseHelpersService.CheckAndUpdateTablesAsync([WiserTableNames.WiserLoginLog]);
 
                 clientDatabaseConnection.ClearParameters();
                 clientDatabaseConnection.AddParameter("id", decryptedLogId);
@@ -1043,8 +1040,7 @@ ORDER BY username.`value` ASC";
                 await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
 
                 // Make sure the WiserLoginLog exists and is up-to-date.
-                await KeepTablesUpToDateAsync(clientDatabaseConnection.ConnectedDatabaseForWriting ?? clientDatabaseConnection.ConnectedDatabase);
-                await databaseHelpersService.CheckAndUpdateTablesAsync(new List<string> {WiserTableNames.WiserLoginLog});
+                await databaseHelpersService.CheckAndUpdateTablesAsync([WiserTableNames.WiserLoginLog]);
 
                 clientDatabaseConnection.ClearParameters();
                 clientDatabaseConnection.AddParameter("id", decryptedLoginLogId);
@@ -1299,8 +1295,7 @@ ORDER BY username.`value` ASC";
                 await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
 
                 // Make sure the WiserLoginLog exists and is up-to-date.
-                await KeepTablesUpToDateAsync(clientDatabaseConnection.ConnectedDatabaseForWriting ?? clientDatabaseConnection.ConnectedDatabase);
-                await databaseHelpersService.CheckAndUpdateTablesAsync(new List<string> {WiserTableNames.WiserLoginLog});
+                await databaseHelpersService.CheckAndUpdateTablesAsync([WiserTableNames.WiserLoginLog]);
 
                 clientDatabaseConnection.ClearParameters();
                 clientDatabaseConnection.AddParameter("user_id", userId);
@@ -1333,7 +1328,7 @@ ORDER BY username.`value` ASC";
         public string SetUpTotpAuthentication(string account, string key)
         {
             var twoFactorAuthenticator = new TwoFactorAuthenticator();
-            var setupInfo = twoFactorAuthenticator.GenerateSetupCode("Wiser", account, key, false, 3);
+            var setupInfo = twoFactorAuthenticator.GenerateSetupCode("Wiser", account, key, false);
             return setupInfo.QrCodeSetupImageUrl;
         }
 
@@ -1461,60 +1456,6 @@ ON DUPLICATE KEY UPDATE `value` = VALUES(value);";
             await connectionToUse.ExecuteAsync(query);
 
             return (true, false);
-        }
-
-        /// <summary>
-        /// Checks if the MySQL tables for the login log is up-to-date.
-        /// </summary>
-        private async Task KeepTablesUpToDateAsync(string databaseName)
-        {
-            var lastTableUpdates = await databaseHelpersService.GetLastTableUpdatesAsync(databaseName);
-
-            // Check if the login log table needs to be updated.
-            if (!await databaseHelpersService.TableExistsAsync(WiserTableNames.WiserDashboard) || (lastTableUpdates.TryGetValue(WiserTableNames.WiserDashboard, out var value) && value >= new DateTime(2023, 2, 23)))
-            {
-                return;
-            }
-
-            // Add column.
-            var column = new ColumnSettingsModel("time_active_in_seconds", MySqlDbType.Int64, notNull: true, defaultValue: "0", addAfterColumnName: "user_id");
-            await databaseHelpersService.AddColumnToTableAsync(WiserTableNames.WiserLoginLog, column, false, databaseName);
-
-            // Convert and drop the "time_active" column if it still exists.
-            if (await databaseHelpersService.ColumnExistsAsync(WiserTableNames.WiserLoginLog, "time_active", databaseName))
-            {
-                await ConvertTimeSpanToSecondsAsync(WiserTableNames.WiserLoginLog, databaseName, "time_active", "time_active_in_seconds");
-                await databaseHelpersService.DropColumnAsync(WiserTableNames.WiserLoginLog, "time_active", databaseName);
-            }
-
-            clientDatabaseConnection.ClearParameters();
-            clientDatabaseConnection.AddParameter("tableName", WiserTableNames.WiserLoginLog);
-            clientDatabaseConnection.AddParameter("lastUpdate", DateTime.Now);
-            var lastUpdateData = await clientDatabaseConnection.GetAsync($"SELECT NULL FROM `{WiserTableNames.WiserTableChanges}` WHERE `name` = ?tableName");
-            if (lastUpdateData.Rows.Count == 0)
-            {
-                await clientDatabaseConnection.ExecuteAsync($"INSERT INTO `{WiserTableNames.WiserTableChanges}` (`name`, last_update) VALUES (?tableName, ?lastUpdate)");
-            }
-            else
-            {
-                await clientDatabaseConnection.ExecuteAsync($"UPDATE `{WiserTableNames.WiserTableChanges}` SET last_update = ?lastUpdate WHERE `name` = ?tableName LIMIT 1");
-            }
-        }
-
-        private async Task ConvertTimeSpanToSecondsAsync(string tableName, string databaseName, string oldColumnName, string newColumnName)
-        {
-            var queryDatabasePart = !String.IsNullOrWhiteSpace(databaseName) ? $"`{databaseName}`." : String.Empty;
-
-            var convertDataTable = await clientDatabaseConnection.GetAsync($"SELECT id, `{oldColumnName}` FROM {queryDatabasePart}`{tableName}`");
-            foreach (var dataRow in convertDataTable.Rows.Cast<DataRow>())
-            {
-                var seconds = Convert.ToInt32(Math.Floor(dataRow.Field<TimeSpan>(oldColumnName).TotalSeconds));
-
-                clientDatabaseConnection.ClearParameters();
-                clientDatabaseConnection.AddParameter("tableId", Convert.ToUInt64(dataRow["id"]));
-                clientDatabaseConnection.AddParameter("seconds", seconds);
-                await clientDatabaseConnection.ExecuteAsync($"UPDATE `{tableName}` SET `{newColumnName}` = ?seconds WHERE id = ?tableId");
-            }
         }
     }
 }


### PR DESCRIPTION
The `KeepTablesUpToDateAsync` method in `DashboardService` and `UsersService` were only needed to convert some old column to a new column. This is no longer required, so they have been removed.

Note: The change on line 1331 in `UsersService.cs` was due to the IDE warning about an optional parameter receiving a value that matched the default value, which is pointless, so I removed it.

There is no Asana ticket for this PR.