### PR TITLE
Wiser 1 to Wiser 3 templatemodule

### DIFF
--- a/Api/Modules/Templates/Controllers/TemplatesController.cs
+++ b/Api/Modules/Templates/Controllers/TemplatesController.cs
@@ -511,7 +511,7 @@ namespace Api.Modules.Templates.Controllers
         [HttpPost, Route("import-legacy"), ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         public async Task<IActionResult> ConvertLegacyTemplatesToNewTemplatesAsync()
         {
-            return (await templatesService.ConvertLegacyTemplatesToNewTemplatesAsync()).GetHttpResponseMessage();
+            return (await templatesService.ConvertLegacyTemplatesToNewTemplatesAsync((ClaimsIdentity)User.Identity)).GetHttpResponseMessage();
         }
     }
 }

--- a/Api/Modules/Templates/Controllers/TemplatesController.cs
+++ b/Api/Modules/Templates/Controllers/TemplatesController.cs
@@ -5,7 +5,6 @@ using System.Net.Mime;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Api.Core.Models;
-using Api.Modules.Tenants.Models;
 using Api.Modules.Kendo.Enums;
 using Api.Modules.Templates.Interfaces;
 using Api.Modules.Templates.Models.History;
@@ -13,6 +12,7 @@ using Api.Modules.Templates.Models.Measurements;
 using Api.Modules.Templates.Models.Other;
 using Api.Modules.Templates.Models.Preview;
 using Api.Modules.Templates.Models.Template;
+using Api.Modules.Tenants.Models;
 using GeeksCoreLibrary.Core.Enums;
 using GeeksCoreLibrary.Core.Extensions;
 using GeeksCoreLibrary.Core.Models;
@@ -503,6 +503,15 @@ namespace Api.Modules.Templates.Controllers
             bool getDailyAverage = false, DateTime? start = null, DateTime? end = null)
         {
             return (await templatesService.GetRenderLogsAsync(templateId, version, urlRegex, environment, userId, languageCode, pageSize, pageNumber, getDailyAverage, start, end)).GetHttpResponseMessage();
+        }
+
+        /// <summary>
+        /// Converts a JCL template to a GCL template.
+        /// </summary>
+        [HttpPost, Route("import-legacy"), ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        public async Task<IActionResult> ConvertLegacyTemplatesToNewTemplatesAsync()
+        {
+            return (await templatesService.ConvertLegacyTemplatesToNewTemplatesAsync()).GetHttpResponseMessage();
         }
     }
 }

--- a/Api/Modules/Templates/Interfaces/DataLayer/ITemplateDataService.cs
+++ b/Api/Modules/Templates/Interfaces/DataLayer/ITemplateDataService.cs
@@ -116,12 +116,13 @@ namespace Api.Modules.Templates.Interfaces.DataLayer
         /// Creates an empty template with the given name, type and parent template.
         /// </summary>
         /// <param name="name">The name to give the template that will be created.</param>
-        /// <param name="parent">The id of the parent template of the template that will be created.</param>
+        /// <param name="parent">The id of the parent template of the template that will be created. Enter null to add something to the root.</param>
         /// <param name="type">The type of the new template that will be created.</param>
         /// <param name="username">The name of the authenticated user.</param>
         /// <param name="editorValue">The value to be inserted into the editor. This will be empty for blank templates.</param>
+        /// <param name="ordering">Optional: The order number of the template. Leave empty to add it to the bottom. This will not update the ordering of any other templates, so make sure the order number doesn't exist yet if you enter one.</param>
         /// <returns>The id of the newly created template. This can be used to update the interface accordingly.</returns>
-        Task<int> CreateAsync(string name, int parent, TemplateTypes type, string username, string editorValue);
+        Task<int> CreateAsync(string name, int? parent, TemplateTypes type, string username, string editorValue = null, int? ordering  = null);
 
         /// <summary>
         /// Makes sure that the ordering of a tree view is correct, to prevent issues with drag and drop in the tree view.
@@ -148,7 +149,7 @@ namespace Api.Modules.Templates.Interfaces.DataLayer
         /// </summary>
         /// <param name="templateId">The ID of the template.</param>
         /// <returns>The current highest order number.</returns>
-        Task<int> GetHighestOrderNumberOfChildrenAsync(int templateId);
+        Task<int> GetHighestOrderNumberOfChildrenAsync(int? templateId);
 
         /// <summary>
         /// Moves a template to a new position.

--- a/Api/Modules/Templates/Interfaces/ITemplatesService.cs
+++ b/Api/Modules/Templates/Interfaces/ITemplatesService.cs
@@ -293,5 +293,10 @@ namespace Api.Modules.Templates.Interfaces
             string urlRegex = null, Environments? environment = null, ulong userId = 0,
             string languageCode = null, int pageSize = 500, int pageNumber = 1,
             bool getDailyAverage = false, DateTime? start = null, DateTime? end = null);
+
+        /// <summary>
+        /// Converts a JCL template to a GCL template.
+        /// </summary>
+        Task<ServiceResult<bool>> ConvertLegacyTemplatesToNewTemplatesAsync();
     }
 }

--- a/Api/Modules/Templates/Interfaces/ITemplatesService.cs
+++ b/Api/Modules/Templates/Interfaces/ITemplatesService.cs
@@ -44,7 +44,7 @@ namespace Api.Modules.Templates.Interfaces
         /// Gets a query from the wiser database and executes it in the tenant database.
         /// </summary>
         /// <param name="identity">The identity of the authenticated user.</param>
-        /// <param name="templateName">The encrypted name of the wiser template.</param>
+        /// <param name="templateName">The encrypted name of the wiser template.</param>Nite
         /// <param name="requestPostData">Optional: The post data from the request, if the content type was application/x-www-form-urlencoded. This is for backwards compatibility.</param>
         Task<ServiceResult<JToken>> GetAndExecuteQueryAsync(ClaimsIdentity identity, string templateName, IFormCollection requestPostData = null);
 
@@ -297,6 +297,7 @@ namespace Api.Modules.Templates.Interfaces
         /// <summary>
         /// Converts a JCL template to a GCL template.
         /// </summary>
-        Task<ServiceResult<bool>> ConvertLegacyTemplatesToNewTemplatesAsync();
+        /// <param name="identity">The identity of the authenticated user.</param>
+        Task<ServiceResult<bool>> ConvertLegacyTemplatesToNewTemplatesAsync(ClaimsIdentity identity);
     }
 }

--- a/Api/Modules/Templates/Services/CachedTemplatesService.cs
+++ b/Api/Modules/Templates/Services/CachedTemplatesService.cs
@@ -237,5 +237,11 @@ namespace Api.Modules.Templates.Services
         {
             return await templatesService.GetRenderLogsAsync(templateId, version, urlRegex, environment, userId, languageCode, pageSize, pageNumber, getDailyAverage, start, end);
         }
+
+        /// <inheritdoc />
+        public async Task<ServiceResult<bool>> ConvertLegacyTemplatesToNewTemplatesAsync()
+        {
+            return await templatesService.ConvertLegacyTemplatesToNewTemplatesAsync();
+        }
     }
 }

--- a/Api/Modules/Templates/Services/CachedTemplatesService.cs
+++ b/Api/Modules/Templates/Services/CachedTemplatesService.cs
@@ -239,9 +239,9 @@ namespace Api.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public async Task<ServiceResult<bool>> ConvertLegacyTemplatesToNewTemplatesAsync()
+        public async Task<ServiceResult<bool>> ConvertLegacyTemplatesToNewTemplatesAsync(ClaimsIdentity identity)
         {
-            return await templatesService.ConvertLegacyTemplatesToNewTemplatesAsync();
+            return await templatesService.ConvertLegacyTemplatesToNewTemplatesAsync(identity);
         }
     }
 }

--- a/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
+++ b/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
@@ -991,9 +991,9 @@ AND otherVersion.id IS NULL";
         }
 
         /// <inheritdoc/>
-        public async Task<int> CreateAsync(string name, int parent, TemplateTypes type, string username, string editorValue)
+        public async Task<int> CreateAsync(string name, int? parent, TemplateTypes type, string username, string editorValue = null, int? ordering  = null)
         {
-            var ordering = await GetHighestOrderNumberOfChildrenAsync(parent) + 1;
+            ordering ??= await GetHighestOrderNumberOfChildrenAsync(parent) + 1;
             clientDatabaseConnection.ClearParameters();
             clientDatabaseConnection.AddParameter("name", name);
             clientDatabaseConnection.AddParameter("parent", parent);
@@ -1001,12 +1001,12 @@ AND otherVersion.id IS NULL";
             clientDatabaseConnection.AddParameter("now", DateTime.Now);
             clientDatabaseConnection.AddParameter("username", username);
             clientDatabaseConnection.AddParameter("ordering", ordering);
-            clientDatabaseConnection.AddParameter("editorval", editorValue);
+            clientDatabaseConnection.AddParameter("editorValue", editorValue);
 
             var dataTable = await clientDatabaseConnection.GetAsync(@$"SET @id = (SELECT MAX(template_id)+1 FROM {WiserTableNames.WiserTemplate});
-                                                            INSERT INTO {WiserTableNames.WiserTemplate} (parent_id, template_name, template_type, version, template_id, added_on, added_by, changed_on, changed_by, published_environment, ordering, template_data, cache_minutes)
-                                                            VALUES (?parent, ?name, ?type, 1, @id, ?now, ?username, ?now, ?username, 1, ?ordering, ?editorval, -1);
-                                                            SELECT @id;");
+INSERT INTO {WiserTableNames.WiserTemplate} (parent_id, template_name, template_type, version, template_id, added_on, added_by, changed_on, changed_by, published_environment, ordering, template_data, cache_minutes)
+VALUES (?parent, ?name, ?type, 1, @id, ?now, ?username, ?now, ?username, 1, ?ordering, ?editorValue, -1);
+SELECT @id;");
 
             return Convert.ToInt32(dataTable.Rows[0]["@id"]);
         }
@@ -1089,7 +1089,7 @@ LIMIT 1";
         }
 
         /// <inheritdoc />
-        public async Task<int> GetHighestOrderNumberOfChildrenAsync(int templateId)
+        public async Task<int> GetHighestOrderNumberOfChildrenAsync(int? templateId)
         {
             clientDatabaseConnection.ClearParameters();
             clientDatabaseConnection.AddParameter("id", templateId);

--- a/Api/Modules/Templates/Services/TemplatesService.cs
+++ b/Api/Modules/Templates/Services/TemplatesService.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using Api.Core.Helpers;
 using Api.Core.Interfaces;
 using Api.Core.Models;
@@ -27,6 +28,20 @@ using Api.Modules.Templates.Models.Measurements;
 using Api.Modules.Templates.Models.Other;
 using Api.Modules.Templates.Models.Template;
 using Api.Modules.Tenants.Interfaces;
+using GeeksCoreLibrary.Components.Account;
+using GeeksCoreLibrary.Components.DataSelectorParser;
+using GeeksCoreLibrary.Components.Filter;
+using GeeksCoreLibrary.Components.Pagination;
+using GeeksCoreLibrary.Components.Pagination.Models;
+using GeeksCoreLibrary.Components.Repeater;
+using GeeksCoreLibrary.Components.Repeater.Models;
+using GeeksCoreLibrary.Components.ShoppingBasket;
+using GeeksCoreLibrary.Components.ShoppingBasket.Models;
+using GeeksCoreLibrary.Components.WebForm;
+using GeeksCoreLibrary.Components.WebForm.Models;
+using GeeksCoreLibrary.Components.WebPage;
+using GeeksCoreLibrary.Components.WebPage.Models;
+using GeeksCoreLibrary.Core.Cms;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Enums;
 using GeeksCoreLibrary.Core.Extensions;
@@ -53,6 +68,7 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MySql.Data.MySqlClient;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUglify;
 using NUglify.JavaScript;
@@ -2186,7 +2202,7 @@ LIMIT 1";
         /// Converts Wiser 1 templates to the Wiser 3 format.
         /// </summary>
         /// <returns></returns>
-        public async Task<ServiceResult<bool>> ConvertLegacyTemplatesToNewTemplates()
+        public async Task<ServiceResult<bool>> ConvertLegacyTemplatesToNewTemplatesAsync()
         {
             // Make sure the tables are up-to-date.
             await databaseHelpersService.CheckAndUpdateTablesAsync(new List<string>
@@ -2244,6 +2260,15 @@ SELECT
     IFNULL(item.lastchangedby, item.createdby) AS changed_by,
     IF(template.istest = 1, 2, 0) + IF(template.isacceptance = 1, 4, 0) + IF(template.islive = 1, 8, 0) AS published_environment,
     template.usecache AS use_cache,
+    template.cacheminutes AS cache_minutes,
+    template.handlerequest AS handle_request,
+    template.handlesession AS handle_session,
+    template.handleobjects AS handle_objects,
+    template.handlestandards AS handle_standards,
+    template.handletranslations AS handle_translations,
+    template.handledynamiccontent AS handle_dynamic_content,
+    template.handlelogicblocks AS handle_logic_blocks,
+    template.handlemutators AS handle_mutators,
     template.issecure AS login_required,
     template.securedsessionprefix AS login_session_prefix,
     CONCAT_WS(',', template.jstemplates, template.csstemplates) AS linked_templates,
@@ -2287,147 +2312,171 @@ JOIN (
 ) AS lowestVersionToConvert ON lowestVersionToConvert.id = item.id AND (template.id IS NULL OR template.version >= lowestVersionToConvert.version)
 WHERE template.templatetype IS NULL OR template.templatetype <> 'normal'";
 
-            await using var reader = await clientDatabaseConnection.GetReaderAsync(query);
-            while (await reader.ReadAsync())
+            await clientDatabaseConnection.BeginTransactionAsync();
+            try
             {
-                // Get template type.
-                var templateType = TemplateTypes.Directory;
-                if (!reader.GetBoolean("is_directory"))
+                dataTable = await clientDatabaseConnection.GetAsync(query);
+                foreach (DataRow dataRow in dataTable.Rows)
                 {
-                    var path = reader.GetStringHandleNull("path");
-
-                    if (path.Contains("/html/", StringComparison.OrdinalIgnoreCase))
+                    // Get template type.
+                    var templateType = TemplateTypes.Directory;
+                    if (!Convert.ToBoolean(dataRow["is_directory"]))
                     {
-                        templateType = TemplateTypes.Html;
+                        var path = dataRow.Field<string>("path") ?? "";
+
+                        if (path.Contains("/html/", StringComparison.OrdinalIgnoreCase))
+                        {
+                            templateType = TemplateTypes.Html;
+                        }
+                        else if (path.Contains("/css/", StringComparison.OrdinalIgnoreCase))
+                        {
+                            templateType = TemplateTypes.Css;
+                        }
+                        else if (path.Contains("/scss/", StringComparison.OrdinalIgnoreCase))
+                        {
+                            templateType = TemplateTypes.Scss;
+                        }
+                        else if (path.Contains("/scripts/", StringComparison.OrdinalIgnoreCase))
+                        {
+                            templateType = TemplateTypes.Js;
+                        }
+                        else if (path.Contains("/query/", StringComparison.OrdinalIgnoreCase))
+                        {
+                            templateType = TemplateTypes.Query;
+                        }
+                        else if (path.Contains("/ais/", StringComparison.OrdinalIgnoreCase))
+                        {
+                            templateType = TemplateTypes.Xml;
+                        }
+                        else if (path.Contains("/routines/", StringComparison.OrdinalIgnoreCase))
+                        {
+                            templateType = TemplateTypes.Routine;
+                        }
                     }
-                    else if (path.Contains("/css/", StringComparison.OrdinalIgnoreCase))
+
+                    // Combine the wiser CDN files with the external files, because we don't use Wiser CDN anymore in Wiser 3.
+                    var cdnDirectory = dataRow.Field<string>("type");
+                    if (String.Equals(cdnDirectory, "js"))
                     {
-                        templateType = TemplateTypes.Css;
+                        cdnDirectory = "scripts";
                     }
-                    else if (path.Contains("/scss/", StringComparison.OrdinalIgnoreCase))
+
+                    var externalFiles = dataRow.Field<string>("external_files") ?? "";
+                    var wiserCdnTemplates = dataRow.Field<string>("wiser_cdn_templates") ?? "";
+                    var allExternalFiles = externalFiles.Split(';').Where(f => !String.IsNullOrWhiteSpace(f)).ToList();
+                    allExternalFiles.AddRange(wiserCdnTemplates.Split(';').Where(f => !String.IsNullOrWhiteSpace(f)).Select(filename => $"https://app.wiser.nl/{cdnDirectory}/cdn/{filename}"));
+
+                    externalFiles = String.Join(";", allExternalFiles);
+
+                    var content = dataRow.Field<string>("template_data") ?? "";
+                    var minifiedContent = dataRow.Field<string>("template_data_minified") ?? "";
+
+                    // Convert dynamic components placeholders from Wiser 1 to Wiser 3 format.
+                    if (templateType == TemplateTypes.Html)
                     {
-                        templateType = TemplateTypes.Scss;
+                        content = ConvertDynamicComponentsFromLegacyToNewInHtml(content);
+                        minifiedContent = ConvertDynamicComponentsFromLegacyToNewInHtml(minifiedContent);
                     }
-                    else if (path.Contains("/scripts/", StringComparison.OrdinalIgnoreCase))
+
+                    if (templateType is TemplateTypes.Html or TemplateTypes.Query)
                     {
-                        templateType = TemplateTypes.Js;
+                        content = ConvertLegacyReplacementMethodsToNewReplacementMethods(content);
+                        minifiedContent = ConvertLegacyReplacementMethodsToNewReplacementMethods(minifiedContent);
                     }
-                    else if (path.Contains("/query/", StringComparison.OrdinalIgnoreCase))
-                    {
-                        templateType = TemplateTypes.Query;
-                    }
-                    // Support legacy AIS
-                    else if (path.Contains("/ais/", StringComparison.OrdinalIgnoreCase) || path.Contains("/services/", StringComparison.OrdinalIgnoreCase))
-                    {
-                        templateType = TemplateTypes.Xml;
-                    }
-                    else if (path.Contains("/routines/", StringComparison.OrdinalIgnoreCase))
-                    {
-                        templateType = TemplateTypes.Routine;
-                    }
-                }
 
-                // Combine the wiser CDN files with the external files, because we don't use Wiser CDN anymore in Wiser 3.
-                var cdnDirectory = reader.GetStringHandleNull("type");
-                if (String.Equals(cdnDirectory, "js"))
-                {
-                    cdnDirectory = "scripts";
-                }
+                    var templateId = dataRow["template_id"];
+                    var publishedEnvironment = dataRow["published_environment"];
+                    var changedOn = dataRow["changed_on"];
+                    var changedBy = dataRow["changed_by"];
+                    clientDatabaseConnection.ClearParameters();
+                    clientDatabaseConnection.AddParameter("parent_id", dataRow["parent_id"]);
+                    clientDatabaseConnection.AddParameter("template_name", dataRow["template_name"]);
+                    clientDatabaseConnection.AddParameter("template_data", content);
+                    clientDatabaseConnection.AddParameter("template_data_minified", minifiedContent);
+                    clientDatabaseConnection.AddParameter("template_type", templateType);
+                    clientDatabaseConnection.AddParameter("version", dataRow["version"]);
+                    clientDatabaseConnection.AddParameter("template_id", templateId);
+                    clientDatabaseConnection.AddParameter("changed_on", changedOn);
+                    clientDatabaseConnection.AddParameter("changed_by", changedBy);
+                    clientDatabaseConnection.AddParameter("published_environment", publishedEnvironment);
+                    clientDatabaseConnection.AddParameter("use_cache", dataRow.IsNull("use_cache") ? 0 : dataRow["use_cache"]);
+                    clientDatabaseConnection.AddParameter("cache_minutes", dataRow.IsNull("cache_minutes") ? 0 : dataRow["cache_minutes"]);
+                    clientDatabaseConnection.AddParameter("handle_request", dataRow.IsNull("handle_request") ? 0 : dataRow["handle_request"]);
+                    clientDatabaseConnection.AddParameter("handle_session", dataRow.IsNull("handle_session") ? 0 : dataRow["handle_session"]);
+                    clientDatabaseConnection.AddParameter("handle_objects", dataRow.IsNull("handle_objects") ? 0 : dataRow["handle_objects"]);
+                    clientDatabaseConnection.AddParameter("handle_standards", dataRow.IsNull("handle_standards") ? 0 : dataRow["handle_standards"]);
+                    clientDatabaseConnection.AddParameter("handle_translations", dataRow.IsNull("handle_translations") ? 0 : dataRow["handle_translations"]);
+                    clientDatabaseConnection.AddParameter("handle_dynamic_content", dataRow.IsNull("handle_dynamic_content") ? 0 : dataRow["handle_dynamic_content"]);
+                    clientDatabaseConnection.AddParameter("handle_logic_blocks", dataRow.IsNull("handle_logic_blocks") ? 0 : dataRow["handle_logic_blocks"]);
+                    clientDatabaseConnection.AddParameter("handle_mutators", dataRow.IsNull("handle_mutators") ? 0 : dataRow["handle_mutators"]);
+                    clientDatabaseConnection.AddParameter("login_required", dataRow.IsNull("login_required") ? 0 : dataRow["login_required"]);
+                    clientDatabaseConnection.AddParameter("login_session_prefix", dataRow["login_session_prefix"]);
+                    clientDatabaseConnection.AddParameter("linked_templates", dataRow["linked_templates"]);
+                    clientDatabaseConnection.AddParameter("ordering", dataRow.IsNull("ordering") ? 0 : dataRow["ordering"]);
+                    clientDatabaseConnection.AddParameter("insert_mode", dataRow.IsNull("insert_mode") ? 0 : dataRow["insert_mode"]);
+                    clientDatabaseConnection.AddParameter("load_always", dataRow.IsNull("load_always") ? 0 : dataRow["load_always"]);
+                    clientDatabaseConnection.AddParameter("url_regex", dataRow["url_regex"]);
+                    clientDatabaseConnection.AddParameter("external_files", externalFiles);
+                    clientDatabaseConnection.AddParameter("grouping_create_object_instead_of_array", dataRow.IsNull("grouping_create_object_instead_of_array") ? 0 : dataRow["grouping_create_object_instead_of_array"]);
+                    clientDatabaseConnection.AddParameter("grouping_prefix", dataRow["grouping_prefix"]);
+                    clientDatabaseConnection.AddParameter("grouping_key", dataRow["grouping_key"]);
+                    clientDatabaseConnection.AddParameter("grouping_key_column_name", dataRow["grouping_key_column_name"]);
+                    clientDatabaseConnection.AddParameter("grouping_value_column_name", dataRow["grouping_value_column_name"]);
+                    clientDatabaseConnection.AddParameter("is_scss_include_template", dataRow.IsNull("is_scss_include_template") ? 0 : dataRow["is_scss_include_template"]);
+                    clientDatabaseConnection.AddParameter("use_in_wiser_html_editors", dataRow.IsNull("use_in_wiser_html_editors") ? 0 : dataRow["use_in_wiser_html_editors"]);
+                    await clientDatabaseConnection.InsertOrUpdateRecordBasedOnParametersAsync(WiserTableNames.WiserTemplate, 0);
 
-                var externalFiles = reader.GetStringHandleNull("external_files");
-                var wiserCdnTemplates = reader.GetStringHandleNull("wiser_cdn_templates");
-                var allExternalFiles = externalFiles.Split(';').ToList();
-                allExternalFiles.AddRange(wiserCdnTemplates.Select(filename => $"https://app.wiser.nl/{cdnDirectory}/cdn/{filename}"));
-
-                externalFiles = String.Join(";", allExternalFiles);
-
-                var content = reader.GetStringHandleNull("template_data");
-                var minifiedContent = reader.GetStringHandleNull("template_data_minified");
-
-                // Convert dynamic components placeholders from Wiser 1 to Wiser 3 format.
-                if (templateType == TemplateTypes.Html)
-                {
-                    content = ConvertDynamicComponentsFromLegacyToNewInHtml(content);
-                    minifiedContent = ConvertDynamicComponentsFromLegacyToNewInHtml(minifiedContent);
-                }
-
-                var urlRegex = reader.GetStringHandleNull("url_regex");
-
-                // Handle routine settings.
-                var routineType = RoutineTypes.Unknown;
-                string routineParameters = null;
-                string routineReturnType = null;
-
-                if (templateType == TemplateTypes.Routine)
-                {
-                    var legacyType = reader.GetStringHandleNull("type");
-                    routineType = legacyType switch
-                    {
-                        "FUNCTION" => RoutineTypes.Function,
-                        "PROCEDURE" => RoutineTypes.Procedure,
-                        _ => routineType
-                    };
-
-                    routineParameters = reader.GetStringHandleNull("routine_parameters");
-                    // Old templates module used the "urlregex" field to store the return type.
-                    routineReturnType = urlRegex;
-
-                    // Set url_regex to null in Wiser 3 template for routine templates.
-                    urlRegex = null;
-                }
-
-                // TODO: Make method for converting legacy replacements (such as {title_htmlencode}) to GCL replacements (such as {title:HtmlEncode}).
-
-                clientDatabaseConnection.ClearParameters();
-                clientDatabaseConnection.AddParameter("parent_id", reader.GetValue("parent_id"));
-                clientDatabaseConnection.AddParameter("template_name", reader.GetValue("template_name"));
-                clientDatabaseConnection.AddParameter("template_data", content);
-                clientDatabaseConnection.AddParameter("template_data_minified", minifiedContent);
-                clientDatabaseConnection.AddParameter("template_type", templateType);
-                clientDatabaseConnection.AddParameter("version", reader.GetValue("version"));
-                clientDatabaseConnection.AddParameter("template_id", reader.GetValue("template_id"));
-                clientDatabaseConnection.AddParameter("changed_on", reader.GetValue("changed_on"));
-                clientDatabaseConnection.AddParameter("changed_by", reader.GetValue("changed_by"));
-                clientDatabaseConnection.AddParameter("published_environment", reader.GetValue("published_environment"));
-                clientDatabaseConnection.AddParameter("cache_minutes", reader.GetValue("cache_minutes"));
-                clientDatabaseConnection.AddParameter("login_required", reader.GetValue("login_required"));
-                clientDatabaseConnection.AddParameter("login_session_prefix", reader.GetValue("login_session_prefix"));
-                clientDatabaseConnection.AddParameter("linked_templates", reader.GetValue("linked_templates"));
-                clientDatabaseConnection.AddParameter("ordering", reader.GetValue("ordering"));
-                clientDatabaseConnection.AddParameter("insert_mode", reader.GetValue("insert_mode"));
-                clientDatabaseConnection.AddParameter("load_always", reader.GetValue("load_always"));
-                clientDatabaseConnection.AddParameter("disable_minifier", reader.GetValue("disable_minifier"));
-                clientDatabaseConnection.AddParameter("url_regex", urlRegex);
-                clientDatabaseConnection.AddParameter("external_files", externalFiles);
-                clientDatabaseConnection.AddParameter("grouping_create_object_instead_of_array", reader.GetValue("grouping_create_object_instead_of_array"));
-                clientDatabaseConnection.AddParameter("grouping_prefix", reader.GetValue("grouping_prefix"));
-                clientDatabaseConnection.AddParameter("grouping_key", reader.GetValue("grouping_key"));
-                clientDatabaseConnection.AddParameter("grouping_key_column_name", reader.GetValue("grouping_key_column_name"));
-                clientDatabaseConnection.AddParameter("grouping_value_column_name", reader.GetValue("grouping_value_column_name"));
-                clientDatabaseConnection.AddParameter("is_scss_include_template", reader.GetValue("is_scss_include_template"));
-                clientDatabaseConnection.AddParameter("use_in_wiser_html_editors", reader.GetValue("use_in_wiser_html_editors"));
-                clientDatabaseConnection.AddParameter("routine_type", (int)routineType);
-                clientDatabaseConnection.AddParameter("routine_parameters", routineParameters);
-                clientDatabaseConnection.AddParameter("routine_return_type", routineReturnType);
-                await clientDatabaseConnection.InsertOrUpdateRecordBasedOnParametersAsync(WiserTableNames.WiserTemplate, 0);
-
-                // Convert dynamic content.
-                if (templateType == TemplateTypes.Html)
-                {
-                    query = @"SELECT *
-                            FROM easy_dynamiccontent
-                            WHERE itemid = ?template_id
-                            AND version = ?version";
-                    dataTable = await clientDatabaseConnection.GetAsync(query);
-                    if (dataTable.Rows.Count == 0)
+                    // Convert dynamic content.
+                    if (templateType != TemplateTypes.Html)
                     {
                         continue;
                     }
 
-                    var legacyComponentName = dataTable.Rows[0].Field<string>("freefield1");
-                    var legacySettingsJson = dataTable.Rows[0].Field<string>("filledvariables");
-                    var newSettings = ConvertDynamicComponentSettingsFromLegacyToNew(legacyComponentName, legacySettingsJson);
+                    query = @"SELECT *
+                        FROM easy_dynamiccontent
+                        WHERE itemid = ?template_id
+                        AND version = ?version";
+                    var dynamicContentDataTable = await clientDatabaseConnection.GetAsync(query);
+                    if (dynamicContentDataTable.Rows.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    foreach (DataRow dynamicContentRow in dynamicContentDataTable.Rows)
+                    {
+                        var contentId = dynamicContentRow.Field<int>("id");
+                        var legacyComponentName = dynamicContentRow.Field<string>("freefield1");
+                        var legacySettingsJson = dynamicContentRow.Field<string>("filledvariables");
+                        var (gclComponentName, gclSettingsJson, title, componentMode) = ConvertDynamicComponentSettingsFromLegacyToNew(legacyComponentName, legacySettingsJson);
+
+                        clientDatabaseConnection.ClearParameters();
+                        clientDatabaseConnection.AddParameter("content_id", contentId);
+                        clientDatabaseConnection.AddParameter("settings", gclSettingsJson);
+                        clientDatabaseConnection.AddParameter("component", gclComponentName);
+                        clientDatabaseConnection.AddParameter("component_mode", componentMode);
+                        clientDatabaseConnection.AddParameter("version", dynamicContentRow.Field<int>("version"));
+                        clientDatabaseConnection.AddParameter("title", title);
+                        clientDatabaseConnection.AddParameter("published_environment", publishedEnvironment);
+                        clientDatabaseConnection.AddParameter("changed_on", changedOn);
+                        clientDatabaseConnection.AddParameter("changed_by", changedBy);
+                        await clientDatabaseConnection.InsertOrUpdateRecordBasedOnParametersAsync(WiserTableNames.WiserDynamicContent, 0);
+
+                        clientDatabaseConnection.ClearParameters();
+                        clientDatabaseConnection.AddParameter("content_id", contentId);
+                        clientDatabaseConnection.AddParameter("destination_template_id", templateId);
+                        clientDatabaseConnection.AddParameter("added_on", changedOn);
+                        clientDatabaseConnection.AddParameter("added_by", changedBy);
+                        await clientDatabaseConnection.ExecuteAsync(@$"INSERT IGNORE INTO {WiserTableNames.WiserTemplateDynamicContent} (content_id, destination_template_id, added_on, added_by)
+                                                                        VALUES (?content_id, ?destination_template_id, ?added_on, ?added_by)");
+                    }
                 }
+
+                await clientDatabaseConnection.CommitTransactionAsync();
+            }
+            catch
+            {
+                await clientDatabaseConnection.RollbackTransactionAsync();
+                throw;
             }
 
             return new ServiceResult<bool>(true);
@@ -2692,6 +2741,283 @@ WHERE template.templatetype IS NULL OR template.templatetype <> 'normal'";
             return new ServiceResult<List<RenderLogModel>>(results);
         }
 
+        /// <summary>
+        /// Converts JCL replacement methods (such as {title_seo}) to GCL replacement methods (such as {title:seo}).
+        /// </summary>
+        /// <param name="input">The string from the JCL to convert.</param>
+        /// <returns>The converted string that can be used in the GCL.</returns>
+        private static string ConvertLegacyReplacementMethodsToNewReplacementMethods(string input)
+        {
+            if (String.IsNullOrWhiteSpace(input))
+            {
+                return input;
+            }
+
+            // Decrypt.
+            input = ConvertEncryptOrDecryptReplacement(input, "decrypt_withdate", "Decrypt", true);
+            input = ConvertEncryptOrDecryptReplacement(input, "normaldecrypt_withdate", "DecryptNormal", true);
+            input = ConvertEncryptOrDecryptReplacement(input, "decrypt", "Decrypt", false);
+            input = ConvertEncryptOrDecryptReplacement(input, "normaldecrypt", "DecryptNormal", false);
+
+            // Encrypt.
+            input = ConvertEncryptOrDecryptReplacement(input, "encrypt_withdate", "Encrypt", true);
+            input = ConvertEncryptOrDecryptReplacement(input, "normalencrypt_withdate", "EncryptNormal", true);
+            input = ConvertEncryptOrDecryptReplacement(input, "encrypt", "Encrypt", false);
+            input = ConvertEncryptOrDecryptReplacement(input, "normalencrypt", "EncryptNormal", false);
+
+            // Likes in queries.
+            if (input.Contains("like", StringComparison.OrdinalIgnoreCase))
+            {
+                input = Regex.Replace(input, @"LIKE '%\[\{(?<variableName>[^}]+?)\}\]%'", "LIKE CONCAT('%', '{${variableName}}', '%')");
+                input = Regex.Replace(input, @"LIKE '%\{(?<variableName>[^}]+?)\}%'", "LIKE CONCAT('%', '{${variableName}}', '%')");
+
+                input = Regex.Replace(input, @"LIKE '%\[\{(?<variableName>[^}]+?)\}\]'", "LIKE CONCAT('%', '{${variableName}}')");
+                input = Regex.Replace(input, @"LIKE '%\{(?<variableName>[^}]+?)\}'", "LIKE CONCAT('%', '{${variableName}}')");
+
+                input = Regex.Replace(input, @"LIKE '\[\{(?<variableName>[^}]+?)\}\]%'", "LIKE CONCAT('{${variableName}}', '%')");
+                input = Regex.Replace(input, @"LIKE '\{(?<variableName>[^}]+?)\}%'", "LIKE CONCAT('{${variableName}}', '%')");
+            }
+
+            input = ConvertBasicReplacement(input, "seo", "Seo");
+            input = ConvertBasicReplacement(input, "htmlencode", "HtmlEncode");
+            input = ConvertBasicReplacement(input, "sha512", "Sha512");
+            input = ConvertBasicReplacement(input, "urldataescape", "UrlEncode");
+            input = ConvertBasicReplacement(input, "urldataunescape", "UrlDecode");
+            input = ConvertBasicReplacement(input, "striphtml", "StripHtml");
+            input = ConvertBasicReplacement(input, "valuta", "Currency");
+            input = ConvertBasicReplacement(input, "valutasup", "CurrencySup");
+            input = ConvertBasicReplacement(input, "jsonsafe", "JsonSafe");
+            input = ConvertBasicReplacement(input, "stripstyle", "StripInlineStyle");
+            input = ConvertBasicReplacement(input, "base64", "Base64");
+            input = ConvertBasicReplacement(input, "price", "Currency", "true");
+            input = ConvertBasicReplacement(input, "currency", "Currency", "true");
+
+            // Miscellaneous conversions.
+            input = input.Replace("{items}", "{items:Raw}");
+
+            return input;
+        }
+
+        /// <summary>
+        /// Converts encryption/decryption replacements from JCL (eg {title_seo}) to GCL (eg {title:Seo}).
+        /// </summary>
+        /// <param name="input">The string from the JCL to do the replacements in.</param>
+        /// <param name="jclSuffix">The JCL suffix (without underscore) for the replacement to handle, such as "seo".</param>
+        /// <param name="gclSuffix">The suffix that it should be in the GCL.</param>
+        /// <param name="withDate">Whether this is an encryption/decryption that uses a datetime to make it invalid after X time.</param>
+        private static string ConvertEncryptOrDecryptReplacement(string input, string jclSuffix, string gclSuffix, bool withDate)
+        {
+            var regex = new Regex(@$"{{(?<variableName>.+)_{jclSuffix}(?<minutesOverride>[\|0-9]*)}}");
+            foreach (Match match in regex.Matches(input))
+            {
+                var minutesOverride = match.Groups["minutesOverride"].Value.TrimStart('|');
+                if (!String.IsNullOrWhiteSpace(minutesOverride))
+                {
+                    minutesOverride = $",{minutesOverride}";
+                }
+                var newVariable = $"{{{match.Groups["variableName"].Value}:{gclSuffix}({withDate}{minutesOverride})}}";
+                input = input.Replace(match.Value, newVariable);
+            }
+
+            return input;
+        }
+
+        /// <summary>
+        /// Converts basic replacements from JCL (eg {title_seo}) to GCL (eg {title:Seo}).
+        /// </summary>
+        /// <param name="input">The string from the JCL to do the replacements in.</param>
+        /// <param name="jclSuffix">The JCL suffix (without underscore) for the replacement to handle, such as "seo".</param>
+        /// <param name="gclSuffix">The suffix that it should be in the GCL.</param>
+        /// <param name="extraParameters">Any extra parameters that the replacement function in the GCL might need.</param>
+        private static string ConvertBasicReplacement(string input, string jclSuffix, string gclSuffix, string extraParameters = "")
+        {
+            if (!String.IsNullOrEmpty(gclSuffix))
+            {
+                gclSuffix = $":{gclSuffix}";
+            }
+
+            var regex = new Regex(@$"{{(?<variableName>[^\{{\}}\n]+)_{jclSuffix}(?<parameters>[\|][^\}}\n]*)?}}");
+            foreach (Match match in regex.Matches(input))
+            {
+                var extraBracketToReplace = "";
+                var parameters = match.Groups["parameters"].Value?.Trim('|');
+
+                if (parameters != null && parameters.StartsWith("{") && !parameters.EndsWith("}"))
+                {
+                    // This is a bit of a hack, because in some cases there will be values like "{price_currency|{culture}}" and our regex will return "{culture" without the last bracket.
+                    // But if we change the regex to include that bracket, then it will often return too much, like "{price_currency|{culture}} <div></div>{otherVariable}" for example.
+                    parameters += "}";
+                    extraBracketToReplace = "}";
+                }
+
+                parameters = String.IsNullOrWhiteSpace(parameters) ? extraParameters : $"{extraParameters},{parameters}";
+                if (!String.IsNullOrEmpty(parameters))
+                {
+                    parameters = $"({parameters})";
+                }
+
+                var newVariable = $"{{{match.Groups["variableName"].Value}{gclSuffix}{parameters}}}";
+                input = input.Replace($"{match.Value}{extraBracketToReplace}", newVariable);
+            }
+
+            return input;
+        }
+
+        /// <summary>
+        /// Converts all dynamic components in an HTML string from JCL tags to GCL tags.
+        /// The JCL uses img tags for components, the GCL uses divs.
+        /// </summary>
+        /// <param name="html">The HTML from the JCL templates module.</param>
+        /// <param name="forJson">Set to true if this is for JSON settings, so that quotes and such will be escaped.</param>
+        /// <returns>The HTML for the GCL templates module.</returns>
+        private static string ConvertDynamicComponentsFromLegacyToNewInHtml(string html, bool forJson = false)
+        {
+            var regex = new Regex(@"<img[^>]*?(?:data=['\""\\]+(?<data>.*?)['\""\\]+[^>]*?)?contentid=['\""\\]+(?<contentId>\d+)['\""\\]+[^>]*?\/?>");
+            var matches = regex.Matches(html);
+            foreach (Match match in matches)
+            {
+                if (!match.Success)
+                {
+                    continue;
+                }
+
+                var dataAttribute = match.Groups["data"].Value;
+                if (!String.IsNullOrWhiteSpace(dataAttribute))
+                {
+                    dataAttribute = $"data=\"{dataAttribute}\"";
+                }
+
+                var componentId = match.Groups["contentId"].Value;
+                var newElement = $"<div class=\"dynamic-content\" {dataAttribute} component-id=\"{componentId}\"><h2>Component {componentId}</h2></div>";
+                html = html.Replace(match.Value, forJson ? HttpUtility.JavaScriptStringEncode(newElement) : newElement);
+            }
+
+            return html;
+        }
+
+        /// <summary>
+        /// Converts the settings JSON from the JCL to the settings JSON for the GCL.
+        /// </summary>
+        /// <param name="legacyComponentName">The name of the component in the JCL.</param>
+        /// <param name="legacySettingsJson">The JSON with the settings from the JCL.</param>
+        /// <returns>The name, settings, title and mode for the GCL component.</returns>
+        private static (string GclComponentName, string GclSettingsJson, string Title, string ComponentMode) ConvertDynamicComponentSettingsFromLegacyToNew(string legacyComponentName, string legacySettingsJson)
+        {
+            legacySettingsJson ??= "";
+
+            string viewComponentName;
+            string newSettingsJson;
+            string title;
+            string componentMode;
+            switch (legacyComponentName)
+            {
+                case "JuiceControlLibrary.MLSimpleMenu":
+                {
+                    viewComponentName = "Repeater";
+                    var legacySettings = JsonConvert.DeserializeObject<MlSimpleMenuLegacySettingsModel>(legacySettingsJson);
+                    componentMode = Repeater.LegacyComponentMode.NonLegacy.ToString();
+                    newSettingsJson = JsonConvert.SerializeObject(legacySettings?.ToSettingsModel());
+                    title = legacySettings?.VisibleDescription;
+                    break;
+                }
+                case "JuiceControlLibrary.SimpleMenu":
+                {
+                    viewComponentName = "Repeater";
+                    var legacySettings = JsonConvert.DeserializeObject<SimpleMenuLegacySettingsModel>(legacySettingsJson);
+                    componentMode = Repeater.LegacyComponentMode.NonLegacy.ToString();
+                    newSettingsJson = JsonConvert.SerializeObject(legacySettings?.ToSettingsModel());
+                    title = legacySettings?.VisibleDescription;
+                    break;
+                }
+                case "JuiceControlLibrary.ProductModule":
+                {
+                    viewComponentName = "Repeater";
+                    var legacySettings = JsonConvert.DeserializeObject<ProductModuleLegacySettingsModel>(legacySettingsJson);
+                    componentMode = Repeater.LegacyComponentMode.NonLegacy.ToString();
+                    newSettingsJson = JsonConvert.SerializeObject(legacySettings?.ToSettingsModel());
+                    title = legacySettings?.VisibleDescription;
+                    break;
+                }
+                case "JuiceControlLibrary.AccountWiser2":
+                {
+                    viewComponentName = "Account";
+                    var legacySettings = JsonConvert.DeserializeObject<CmsSettingsLegacy>(legacySettingsJson);
+                    componentMode = ((Account.ComponentModes)legacySettings.ComponentMode).ToString();
+                    // Settings for account are the same for JCL and GCL.
+                    newSettingsJson = legacySettingsJson;
+                    title = legacySettings?.VisibleDescription;
+                    break;
+                }
+                case "JuiceControlLibrary.ShoppingBasket":
+                {
+                    viewComponentName = "ShoppingBasket";
+                    var legacySettings = JsonConvert.DeserializeObject<ShoppingBasketLegacySettingsModel>(legacySettingsJson);
+                    componentMode = ShoppingBasket.ComponentModes.Legacy.ToString();
+                    newSettingsJson = JsonConvert.SerializeObject(legacySettings?.ToSettingsModel());
+                    title = legacySettings?.VisibleDescription;
+                    break;
+                }
+                case "JuiceControlLibrary.WebPage":
+                {
+                    viewComponentName = "WebPage";
+                    var legacySettings = JsonConvert.DeserializeObject<WebPageLegacySettingsModel>(legacySettingsJson);
+                    componentMode = WebPage.ComponentModes.Render.ToString();
+                    newSettingsJson = JsonConvert.SerializeObject(legacySettings?.ToSettingsModel());
+                    title = legacySettings?.VisibleDescription;
+                    break;
+                }
+                case "JuiceControlLibrary.Pagination":
+                {
+                    viewComponentName = "Pagination";
+                    var legacySettings = JsonConvert.DeserializeObject<PaginationLegacySettingsModel>(legacySettingsJson);
+                    componentMode = Pagination.ComponentModes.Normal.ToString();
+                    newSettingsJson = JsonConvert.SerializeObject(legacySettings?.ToSettingsModel());
+                    title = legacySettings?.VisibleDescription;
+                    break;
+                }
+                case "JuiceControlLibrary.DynamicFilter":
+                {
+                    viewComponentName = "Filter";
+                    var legacySettings = JsonConvert.DeserializeObject<CmsSettingsLegacy>(legacySettingsJson);
+                    componentMode = Filter.ComponentModes.Aggregation.ToString();
+                    // Settings for account are the same for JCL and GCL.
+                    newSettingsJson = legacySettingsJson;
+                    title = legacySettings?.VisibleDescription;
+                    break;
+                }
+                case "JuiceControlLibrary.Sendform":
+                {
+                    viewComponentName = "WebForm";
+                    var legacySettings = JsonConvert.DeserializeObject<WebFormLegacySettingsModel>(legacySettingsJson);
+                    componentMode = WebForm.ComponentModes.BasicForm.ToString();
+                    newSettingsJson = JsonConvert.SerializeObject(legacySettings?.ToSettingsModel());
+                    title = legacySettings?.VisibleDescription;
+                    break;
+                }
+                case "JuiceControlLibrary.Configurator":
+                {
+                    return ("Configurator", legacySettingsJson, "TODO - Configurator - This needs to be converted manually!", "Default");
+                }
+                case "JuiceControlLibrary.DataSelectorParser":
+                {
+                    viewComponentName = "DataSelectorParser";
+                    var legacySettings = JsonConvert.DeserializeObject<CmsSettingsLegacy>(legacySettingsJson);
+                    componentMode = DataSelectorParser.ComponentModes.Render.ToString();
+                    // Settings for account are the same for JCL and GCL.
+                    newSettingsJson = legacySettingsJson;
+                    title = legacySettings?.VisibleDescription;
+                    break;
+                }
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(legacyComponentName), legacyComponentName);
+            }
+
+            newSettingsJson = ConvertDynamicComponentsFromLegacyToNewInHtml(newSettingsJson, true);
+            newSettingsJson = ConvertLegacyReplacementMethodsToNewReplacementMethods(newSettingsJson);
+
+            return (viewComponentName, newSettingsJson, title, componentMode);
+        }
+
         private static string ConvertDynamicComponentsFromLegacyToNewInHtml(string html)
         {
             var regex = new Regex(@"<img[^>]*?(?:data=['""](?<data>.*?)['""][^>]*?)?contentid=['""](?<contentid>\d+)['""][^>]*?\/?>", RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200));
@@ -2714,13 +3040,6 @@ WHERE template.templatetype IS NULL OR template.templatetype <> 'normal'";
             }
 
             return html;
-        }
-
-        private static string ConvertDynamicComponentSettingsFromLegacyToNew(string legacyComponentName, string legacySettingsJson)
-        {
-            // TODO: The main CmsSettingsModel of every component should have a method "ToSettingsModel", which will convert the legacy settings to the new settings. Use that.
-
-            return null;
         }
 
         /// <summary>

--- a/FrontEnd/Modules/Templates/Scripts/Templates.js
+++ b/FrontEnd/Modules/Templates/Scripts/Templates.js
@@ -218,6 +218,11 @@ const moduleSettings = {
                 click: () => this.openCreateNewItemDialog(false)
             });
 
+            $("#importLegacyButton").kendoButton({
+                icon: "import",
+                click: this.importLegacyTemplates.bind(this)
+            });
+
             // Main window
             this.mainWindow = $("#window").kendoWindow({
                 width: "1500",
@@ -1149,7 +1154,7 @@ const moduleSettings = {
 
             const editorElement = $(".editor");
             const editorType = editorElement.data("editorType");
-            
+
             if (editorType === "text/html") {
                 // HTML editor
                 const insertDynamicContentTool = {
@@ -1166,7 +1171,7 @@ const moduleSettings = {
                 const wiserApiRoot = this.settings.wiserApiRoot;
                 const imagesRootId = this.settings.imagesRootId;
                 const filesRootId = this.settings.filesRootId;
-                
+
                 const translationsTool = {
                     name: "wiserTranslation",
                     tooltip: "Vertaling invoegen",
@@ -1178,7 +1183,7 @@ const moduleSettings = {
                     tooltip: "Afbeelding toevoegen",
                     exec: function(e){ Wiser.onHtmlEditorImageExec.call(Wiser, e, $(this).data("kendoEditor"), "templates", imagesRootId); }
                 };
-                
+
                 const fileTool = {
                     name: "wiserFile",
                     tooltip: "Link naar bestand toevoegen",
@@ -2473,7 +2478,7 @@ const moduleSettings = {
             window.processing.removeProcess(process);
             this.loadingNextPart = false;
         }
-        
+
         /**
          * Reloads measurements of the template.
          * @param {any} templateId The ID of the template.
@@ -2974,6 +2979,34 @@ const moduleSettings = {
             const urlRegexHasValue = urlRegexInput.value !== "";
             alwaysLoadCheckbox.disabled = urlRegexHasValue;
             alwaysLoadCheckbox.readOnly = urlRegexHasValue;
+        }
+
+        /**
+         * Imports the templates from the Wiser 1 templates modules into the Wiser 3 templates module.
+         */
+        async importLegacyTemplates() {
+            await kendo.confirm("Weet u zeker dat u de templatemodule van Wiser 1 wilt importeren? De tabellen 'wiser_template' en 'wiser_dynamic_content' moeten leeg zijn voordat u dit doet.");
+
+            const process = `importLegacyTemplates_${Date.now()}`;
+            window.processing.addProcess(process);
+
+            try {
+                const response = await Wiser2.api({
+                    url: `${this.settings.wiserApiRoot}templates/import-legacy`,
+                    dataType: "json",
+                    type: "POST",
+                    contentType: "application/json"
+                });
+
+                await this.loadTabsAndTreeViews();
+
+                window.popupNotification.show(`Templates van Wiser 1 zijn succesvol geïmporteerd.`, "info");
+            } catch (exception) {
+                console.error(exception);
+                kendo.alert("Er is iets fout gegaan, probeer het a.u.b. opnieuw of neem contact op.");
+            }
+
+            window.processing.removeProcess(process);
         }
     }
 

--- a/FrontEnd/Modules/Templates/Scripts/Templates.js
+++ b/FrontEnd/Modules/Templates/Scripts/Templates.js
@@ -266,6 +266,33 @@ const moduleSettings = {
                 return;
             }
 
+            await this.loadTabsAndTreeViews();
+
+            this.searchResultsTreeView = $("#search-results-treeview").kendoTreeView({
+                loadOnDemand: false,
+                dragAndDrop: false,
+                dataTextField: "templateName",
+                dataSpriteCssClassField: "spriteCssClass",
+                select: this.onTreeViewSelect.bind(this),
+            }).data("kendoTreeView");
+
+            this.treeViewContextMenu = $("#treeViewContextMenu").kendoContextMenu({
+                dataSource: [
+                    { text: "Item toevoegen", attr: { action: "addNewItem" } },
+                    { text: "Hernoemen", attr: { action: "rename" } },
+                    { text: "Verwijderen", attr: { action: "delete" } }
+                ],
+                target: ".tabstrip-treeview",
+                filter: ".k-item",
+                open: this.onContextMenuOpen.bind(this),
+                select: this.onContextMenuSelect.bind(this)
+            }).data("kendoContextMenu");
+        }
+
+        /**
+         * Initializes and loads the Kendo components for the main tab strip and the tree views of every tab.
+         */
+        async loadTabsAndTreeViews() {
             // Load the tabs via the API.
             this.treeViewTabs = await Wiser.api({
                 url: `${this.settings.wiserApiRoot}templates/0/tree-view`,
@@ -327,26 +354,6 @@ const moduleSettings = {
                     dataSpriteCssClassField: "spriteCssClass"
                 }).data("kendoTreeView");
             });
-
-            this.searchResultsTreeView = $("#search-results-treeview").kendoTreeView({
-                loadOnDemand: false,
-                dragAndDrop: false,
-                dataTextField: "templateName",
-                dataSpriteCssClassField: "spriteCssClass",
-                select: this.onTreeViewSelect.bind(this),
-            }).data("kendoTreeView");
-
-            this.treeViewContextMenu = $("#treeViewContextMenu").kendoContextMenu({
-                dataSource: [
-                    { text: "Item toevoegen", attr: { action: "addNewItem" } },
-                    { text: "Hernoemen", attr: { action: "rename" } },
-                    { text: "Verwijderen", attr: { action: "delete" } }
-                ],
-                target: ".tabstrip-treeview",
-                filter: ".k-item",
-                open: this.onContextMenuOpen.bind(this),
-                select: this.onContextMenuSelect.bind(this)
-            }).data("kendoContextMenu");
         }
 
         /**
@@ -2991,7 +2998,7 @@ const moduleSettings = {
             window.processing.addProcess(process);
 
             try {
-                const response = await Wiser2.api({
+                const response = await Wiser.api({
                     url: `${this.settings.wiserApiRoot}templates/import-legacy`,
                     dataType: "json",
                     type: "POST",

--- a/FrontEnd/Modules/Templates/Views/Templates/Index.cshtml
+++ b/FrontEnd/Modules/Templates/Views/Templates/Index.cshtml
@@ -51,6 +51,7 @@
             @if (Model.TemplateId == 0)
             {
                 <div class="window-header">
+                    <button id="importLegacyButton" class="k-secondary saveButton">Importeren van Wiser 1</button>
                     <form id="searchForm" class="search-container">
                         <input type="text" placeholder="Zoeken" id="search-field" class="k-input" autocomplete="off">
                         <button class="icon-line-search"></button>
@@ -116,7 +117,7 @@
                     </div>
                 </div>
             </div>
-            
+
             <!-- Item search popup / window -->
             <div id="searchItemsWindow">
                 <div class="pane-content">
@@ -126,7 +127,7 @@
                     </div>
                 </div>
             </div>
-            
+
             <!-- File manager window -->
             <div id="fileManagerWindow" class="popup-container">
                 <div class="horizontal">

--- a/FrontEnd/Modules/Templates/Views/Templates/Tabs/DevelopmentTab.cshtml
+++ b/FrontEnd/Modules/Templates/Views/Templates/Tabs/DevelopmentTab.cshtml
@@ -30,7 +30,6 @@
         }
     </div>
     <footer>
-        <button id="importLegacyButton" class="k-secondary saveButton">Importeren van Wiser 1</button>
         <div class="version-actions">
             <div class="branch-container hidden" id="deployToBranchContainer">
                 <select id="branchesDropDown"></select>

--- a/FrontEnd/Modules/Templates/Views/Templates/Tabs/DevelopmentTab.cshtml
+++ b/FrontEnd/Modules/Templates/Views/Templates/Tabs/DevelopmentTab.cshtml
@@ -30,6 +30,7 @@
         }
     </div>
     <footer>
+        <button id="importLegacyButton" class="k-secondary saveButton">Importeren van Wiser 1</button>
         <div class="version-actions">
             <div class="branch-container hidden" id="deployToBranchContainer">
                 <select id="branchesDropDown"></select>


### PR DESCRIPTION
This adds a button to the Template module that can be used to import data from a Wiser 1 templatemodule. This will then convert most components, replacements etc to the new syntax for the GCL and Wiser 3. This will not give you a 100% working website in most cases, it still requires some manual work after doing the import, but it saves most of the work.

Asana ticket: https://app.asana.com/0/1205090868730163/1201855300969674