### PR TITLE
Bugfix/template history linked templates

### DIFF
--- a/Api/Modules/Templates/Services/DataLayer/HistoryDataService.cs
+++ b/Api/Modules/Templates/Services/DataLayer/HistoryDataService.cs
@@ -114,7 +114,7 @@ WHERE content_id = ?id");
     template.login_role,
     template.login_redirect_url, 
     template.ordering, 
-    GROUP_CONCAT(CONCAT_WS(';', linkedTemplates.template_id, linkedTemplates.template_name, linkedTemplates.template_type)) AS linkedTemplates,
+    GROUP_CONCAT(CONCAT_WS(';', linkedTemplates.template_id, linkedTemplates.template_name, linkedTemplates.template_type)) AS linked_templates,
     template.insert_mode,
     template.load_always,
     template.disable_minifier,
@@ -141,8 +141,7 @@ WHERE content_id = ?id");
     template.default_header_footer_regex,
     template.is_partial,
     template.widget_content,
-    template.widget_location,
-    template.linked_templates
+    template.widget_location
 FROM {WiserTableNames.WiserTemplate} AS template 
 LEFT JOIN {WiserTableNames.WiserTemplateExternalFiles} AS externalFiles ON externalFiles.template_id = template.id
 LEFT JOIN (SELECT linkedTemplate.template_id, template_name, template_type FROM {WiserTableNames.WiserTemplate} linkedTemplate WHERE linkedTemplate.removed = 0 GROUP BY template_id) AS linkedTemplates ON FIND_IN_SET(linkedTemplates.template_id, template.linked_templates)

--- a/Api/Modules/Templates/Services/HistoryService.cs
+++ b/Api/Modules/Templates/Services/HistoryService.cs
@@ -206,7 +206,10 @@ namespace Api.Modules.Templates.Services
                 {
                     if (!newLinkedTemplates.Contains(item))
                     {
-                        historyModel.LinkedTemplateChanges.Add(item.Split(";")[1], new (true, false, TemplateTypes.Normal));
+                        var templateData = item.Split(";");
+                        var id = templateData[0];
+                        var name = templateData[1];
+                        historyModel.LinkedTemplateChanges.Add($"{name} ({id})", new (true, false, TemplateTypes.Normal));
                     }
                 }
             }
@@ -216,7 +219,10 @@ namespace Api.Modules.Templates.Services
                 {
                     if (!oldLinkedTemplates.Contains(item))
                     {
-                        historyModel.LinkedTemplateChanges.Add(item.Split(";")[1], new (false, true, TemplateTypes.Normal));
+                        var templateData = item.Split(";");
+                        var id = templateData[0];
+                        var name = templateData[1];
+                        historyModel.LinkedTemplateChanges.Add( $"{name} ({id})", new (false, true, TemplateTypes.Normal));
                     }
                 }
             }


### PR DESCRIPTION
https://app.asana.com/0/1201027711166952/1204448038757452

Fixes 2 bugs preventing template history tab from loading under certain circumstances.

The first bug was introduced more recently. In the query for the history the linked_template information gets loaded, this should be the id, name and type of the template but a recent change caused this to be overwritted with only the template ids. This meant there was missing data later in de proces stopped the history tab from loading.

Secondly the history tab couldn't handle changed in linked templates when there were multiple templates with the same name.
In the GenerateHistoryModelForTemplates method these names get added to a dictionary. This caused there to be multiple keys with the same name in this dictionary which is not possible. This was solved by changed the key to `<name> (<id>)`. By adding the id to the name the key is always unique and there is the added benefit of making it clear for the human reading the template history which exact template got linked or unlinked.