### PR TITLE
Admin module - Entity tab - Fix for group combobox and dependency dropdownbox

### DIFF
--- a/FrontEnd/Modules/Admin/Scripts/EntityTab.js
+++ b/FrontEnd/Modules/Admin/Scripts/EntityTab.js
@@ -2318,7 +2318,7 @@ export class EntityTab {
         }
 
         $("#EntityTabStrip-2 .right-pane").show();
-        const selectedEntityName = dataItem.entityName;
+        const selectedEntityName = dataItem.entityType;
         const selectedTabName = dataItem.tabName;
         if (this.lastSelectedProperty === index && this.lastSelectedTabname === selectedTabName && !this.isSaveSelect) {
             this.base.openDialog("Item opnieuw openen", "Wilt u dit item opnieuw openen? (u raakt gewijzigde gegevens kwijt)", this.base.kendoPromptType.CONFIRM).then(() => {


### PR DESCRIPTION
The selectedEntityName was undefined so SQL queries returned 0 results. The property needed was actually called entityType.

Fixes both:
https://app.asana.com/0/1205090868730163/1205837166648269
and the groupbox part of
https://app.asana.com/0/1205090868730163/1205837166648264