### PR TITLE
Changed the checked status setting to truthy checks

### DIFF
--- a/FrontEnd/Modules/Admin/Scripts/WiserLinkTab.js
+++ b/FrontEnd/Modules/Admin/Scripts/WiserLinkTab.js
@@ -249,11 +249,11 @@ export class WiserLinkTab {
             return dataItem.duplication === linkDataItem.duplication;
         });
 
-        document.getElementById("wiserLinkUseParentId").checked = linkDataItem.use_item_parent_id === 1;
-        document.getElementById("wiserLinkUseDedicatedTable").checked = linkDataItem.use_dedicated_table === 1;
-        document.getElementById("wiserLinkCascadeDelete").checked = linkDataItem.cascade_delete === 1;
-        document.getElementById("wiserLinkShowInDataSelector").checked = linkDataItem.show_in_data_selector === 1;
-        document.getElementById("wiserLinkShowInTreeView").checked = linkDataItem.show_in_tree_view === 1;
+        document.getElementById("wiserLinkUseParentId").checked = linkDataItem.use_item_parent_id;
+        document.getElementById("wiserLinkUseDedicatedTable").checked = linkDataItem.use_dedicated_table;
+        document.getElementById("wiserLinkCascadeDelete").checked = linkDataItem.cascade_delete;
+        document.getElementById("wiserLinkShowInDataSelector").checked = linkDataItem.show_in_data_selector;
+        document.getElementById("wiserLinkShowInTreeView").checked = linkDataItem.show_in_tree_view;
     }
 
     async reloadWiserLinkList() {


### PR DESCRIPTION
The value of the properties coming from the database can vary between Wiser environments. This is because on some databases the table field is a tinyint of length 1, which results in values of _true_ and _false_. But other databases have the table field as a tinyint without a length, which results in values of _0_ and _1_. So we need to account for both possibilities by using a truthy check.

Asana: https://app.asana.com/0/1205090868730163/1206641938501209