### PR TITLE
Improve the endpoint to get Wiser items from API

### DIFF
--- a/Api/Modules/Items/Controllers/ItemsController.cs
+++ b/Api/Modules/Items/Controllers/ItemsController.cs
@@ -51,13 +51,14 @@ namespace Api.Modules.Items.Controllers
         /// The results will be returned in multiple pages, with a max of 500 items per page.
         /// </summary>
         /// <param name="pagedRequest">Optional: Which page to get and how many items per page to get.</param>
+        /// <param name="useFriendlyPropertyNames">Optional: Whether to use friendly property names or not. Default is <see langword="true"/>.</param>
         /// <param name="filters">Optional: Add filters if you only want specific results.</param>
         /// <returns>A PagedResults with information about the total amount of items, page number etc. The results property contains the actual results, of type FlatItemModel.</returns>
         [HttpGet]
         [ProducesResponseType(typeof(PagedResults<FlatItemModel>), StatusCodes.Status200OK)]
-        public async Task<IActionResult> GetItemsAsync([FromQuery]PagedRequest pagedRequest = null, [FromQuery]WiserItemModel filters = null)
+        public async Task<IActionResult> GetItemsAsync([FromQuery]PagedRequest pagedRequest = null, bool useFriendlyPropertyNames = true, [FromQuery]WiserItemModel filters = null)
         {
-            return (await itemsService.GetItemsAsync((ClaimsIdentity)User.Identity, pagedRequest, filters)).GetHttpResponseMessage();
+            return (await itemsService.GetItemsAsync((ClaimsIdentity)User.Identity, pagedRequest, useFriendlyPropertyNames, filters)).GetHttpResponseMessage();
         }
 
         /// <summary>

--- a/Api/Modules/Items/Interfaces/IItemsService.cs
+++ b/Api/Modules/Items/Interfaces/IItemsService.cs
@@ -21,9 +21,10 @@ namespace Api.Modules.Items.Interfaces
         /// </summary>
         /// <param name="identity">The identity of the authenticated user.</param>
         /// <param name="pagedRequest">Optional: Which page to get and how many items per page to get.</param>
+        /// <param name="useFriendlyPropertyNames">Optional: Whether to use friendly property names or not. Default is <see langword="true"/>.</param>
         /// <param name="filters">Optional: Add filters if you only want specific results.</param>
         /// <returns>A PagedResults with information about the total amount of items, page number etc. The results property contains the actual results, of type FlatItemModel.</returns>
-        Task<ServiceResult<PagedResults<FlatItemModel>>> GetItemsAsync(ClaimsIdentity identity, PagedRequest pagedRequest = null, WiserItemModel filters = null);
+        Task<ServiceResult<PagedResults<FlatItemModel>>> GetItemsAsync(ClaimsIdentity identity, PagedRequest pagedRequest = null, bool useFriendlyPropertyNames = true, WiserItemModel filters = null);
 
         /// <summary>
         /// Creates a duplicate copy of an existing item.


### PR DESCRIPTION
- Title has been added to filter on
- More information is passed to next/previous URLs
- Possibility to disable use of property friendly name. When a friendly name was reused (within groups/tabs) within the entity the JSON gave an error due to duplicate keys

https://app.asana.com/0/1204297502076149/1206449896411068