### PR TITLE
Some improvements to code review functionality of the version control / template module

### DIFF
--- a/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
+++ b/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
@@ -160,6 +160,7 @@ LEFT JOIN {WiserTableNames.WiserTemplateExternalFiles} AS externalFiles ON exter
 WHERE template.template_id = ?templateId
 {publishedVersionWhere}
 AND template.removed = 0
+GROUP BY template.id
 ORDER BY template.version DESC 
 LIMIT 1");
 

--- a/Api/Modules/VersionControl/Models/DynamicContentCommitModel.cs
+++ b/Api/Modules/VersionControl/Models/DynamicContentCommitModel.cs
@@ -87,5 +87,10 @@ namespace Api.Modules.VersionControl.Models
         /// Gets or sets the names of the templates that this content is linked to.
         /// </summary>
         public List<string> TemplateNames { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the component is deleted in this commit.
+        /// </summary>
+        public bool Deleted { get; set; }
     }
 }

--- a/Api/Modules/VersionControl/Models/TemplateCommitModel.cs
+++ b/Api/Modules/VersionControl/Models/TemplateCommitModel.cs
@@ -88,4 +88,9 @@ public class TemplateCommitModel
     /// Gets or sets the name of the user that made the commit.
     /// </summary>
     public string ChangedBy { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the template is deleted in this commit.
+    /// </summary>
+    public bool Deleted { get; set; }
 }

--- a/Api/Modules/VersionControl/Services/DataLayer/CommitDataService.cs
+++ b/Api/Modules/VersionControl/Services/DataLayer/CommitDataService.cs
@@ -56,7 +56,7 @@ public class CommitDataService : ICommitDataService, IScopedService
 	content.changed_on AS content_changed_on,
 	content.changed_by AS content_changed_by,
 	content.component_mode,
-	#contentMaxVersion.version AS max_version,
+	content.removed,
 	IFNULL(testContent.version, 0) AS version_test,
 	IFNULL(acceptanceContent.version, 0) AS version_acceptance,
 	IFNULL(liveContent.version, 0) AS version_live,
@@ -133,7 +133,8 @@ GROUP BY content.content_id";
 			    VersionLive = dataRow.Field<int>("version_live"),
 			    VersionTest = dataRow.Field<int>("version_test"),
 			    TemplateIds = dataRow.Field<string>("template_ids")?.Split(",").Select(Int32.Parse).ToList(),
-			    TemplateNames = dataRow.Field<string>("template_names")?.Split(",").ToList()
+			    TemplateNames = dataRow.Field<string>("template_names")?.Split(",").ToList(),
+			    Deleted = Convert.ToBoolean(dataRow["removed"])
 		    });
 	    }
 
@@ -167,7 +168,8 @@ GROUP BY content.content_id";
 	IFNULL(liveTemplate.version, 0) AS version_live,
 	IFNULL(template.version, 0) <= IFNULL(testTemplate.version, 0) AS test,
 	IFNULL(template.version, 0) <= IFNULL(acceptanceTemplate.version, 0) AS accept,
-	IFNULL(template.version, 0) <= IFNULL(liveTemplate.version, 0) AS live
+	IFNULL(template.version, 0) <= IFNULL(liveTemplate.version, 0) AS live,
+	template.removed
 FROM {WiserTableNames.WiserCommit} AS `commit`
 JOIN {WiserTableNames.WiserCommitTemplate} AS linkToTemplate ON `commit`.id = linkToTemplate.commit_id
 JOIN {WiserTableNames.WiserTemplate} AS template ON linkToTemplate.template_id = template.template_id AND linkToTemplate.version = template.version
@@ -199,7 +201,8 @@ WHERE `commit`.id = ?id";
 			    TemplateName = dataRow.Field<string>("template_name"),
 			    TemplateType = (TemplateTypes)Convert.ToInt32(dataRow["template_type"]),
 			    TemplateParentId = Convert.ToInt32(dataRow["parent_id"]),
-			    TemplateParentName = dataRow.Field<string>("parent_name")
+			    TemplateParentName = dataRow.Field<string>("parent_name"),
+			    Deleted = Convert.ToBoolean(dataRow["removed"])
 		    });
 	    }
 
@@ -308,7 +311,8 @@ WHERE `commit`.id = ?id";
 	parent.template_name AS template_parent,
 	IFNULL(template.version, 0) = IFNULL(testTemplate.version, 0) AS test,
 	IFNULL(template.version, 0) = IFNULL(acceptanceTemplate.version, 0) AS accept,
-	IFNULL(template.version, 0) = IFNULL(liveTemplate.version, 0) AS live 
+	IFNULL(template.version, 0) = IFNULL(liveTemplate.version, 0) AS live,
+	template.removed
 FROM {WiserTableNames.WiserTemplate} AS template
 JOIN {WiserTableNames.WiserTemplate} AS parent ON parent.template_id = template.parent_id AND parent.version = (SELECT MAX(x.version) FROM {WiserTableNames.WiserTemplate} AS x WHERE x.template_id = template.parent_id)
 LEFT JOIN {WiserTableNames.WiserTemplate} AS testTemplate ON testTemplate.template_id = template.template_id AND (testTemplate.published_environment & {(int)Environments.Test}) = {(int)Environments.Test}
@@ -342,7 +346,8 @@ ORDER BY template.changed_on ASC";
 		        VersionLive = dataRow.Field<int>("version_live"),
 		        VersionTest = dataRow.Field<int>("version_test"),
 		        TemplateParentId = dataRow.Field<int>("parent_id"),
-		        TemplateParentName = dataRow.Field<string>("template_parent")
+		        TemplateParentName = dataRow.Field<string>("template_parent"),
+		        Deleted = Convert.ToBoolean(dataRow["removed"])
 	        };
 	        results.Add(item);
         }
@@ -369,7 +374,8 @@ ORDER BY template.changed_on ASC";
 	IFNULL(content.version, 0) = IFNULL(acceptanceContent.version, 0) AS accept,
 	IFNULL(content.version, 0) = IFNULL(liveContent.version, 0) AS live,
 	GROUP_CONCAT(DISTINCT template.template_id) AS template_ids,
-	GROUP_CONCAT(DISTINCT template.template_name) AS template_names
+	GROUP_CONCAT(DISTINCT template.template_name) AS template_names,
+	content.removed
 FROM {WiserTableNames.WiserDynamicContent} AS content
 LEFT JOIN {WiserTableNames.WiserDynamicContent} AS testContent ON testContent.content_id = content.content_id AND (testContent.published_environment & {(int)Environments.Test}) = {(int)Environments.Test}
 LEFT JOIN {WiserTableNames.WiserDynamicContent} AS acceptanceContent ON acceptanceContent.content_id = content.content_id AND (acceptanceContent.published_environment & {(int)Environments.Acceptance}) = {(int)Environments.Acceptance}
@@ -401,7 +407,8 @@ ORDER BY content.changed_on ASC";
 		        VersionLive = dataRow.Field<int>("version_live"),
 		        VersionTest = dataRow.Field<int>("version_test"),
 		        TemplateIds = dataRow.Field<string>("template_ids")?.Split(",").Select(Int32.Parse).ToList(),
-		        TemplateNames = dataRow.Field<string>("template_names")?.Split(",").ToList()
+		        TemplateNames = dataRow.Field<string>("template_names")?.Split(",").ToList(),
+		        Deleted = Convert.ToBoolean(dataRow["removed"])
 	        };
 	        results.Add(item);
         }

--- a/FrontEnd/Modules/VersionControl/Scripts/VersionControl.js
+++ b/FrontEnd/Modules/VersionControl/Scripts/VersionControl.js
@@ -146,8 +146,6 @@ const moduleSettings = {
 
             // Initialize sub classes.
             await this.initializeComponents();
-
-            this.toggleMainLoader(false);
         }
 
         /**
@@ -666,18 +664,31 @@ const moduleSettings = {
                         },
                         {
                             title: "",
-                            width: "40px",
+                            width: "300px",
                             command: [
                                 {
                                     name: "view",
                                     text: "",
                                     iconClass: "view-template-button k-icon k-i-eye",
+                                    visible: function(dataItem) {
+                                        // Note: For some reason Kendo throw an "Uncaught Error: Invalid template" error when using an arrow function here, that's why this is a regular function.
+                                        return !dataItem.deleted;
+                                    },
                                     click: (event) => {
                                         const item = $(event.delegateTarget).data("kendoGrid").dataItem(event.currentTarget.closest("tr"));
                                         let url = `/Modules/Templates?templateId=${item.templateId}&InitialTab=history`;
                                         let title = `${item.templateType.toUpperCase()} template "${item.templateName}" (${item.templateId})`;
                                         this.openPopupWindow(url, title);
                                     }
+                                },
+                                {
+                                    title: "&nbsp;",
+                                    width: "300px",
+                                    visible: function(dataItem) {
+                                        // Note: For some reason Kendo throw an "Uncaught Error: Invalid template" error when using an arrow function here, that's why this is a regular function.
+                                        return dataItem.deleted;
+                                    },
+                                    template: "Deze template is verwijderd met deze versie"
                                 }
                             ]
                         }
@@ -791,12 +802,16 @@ const moduleSettings = {
                         },
                         {
                             title: "",
-                            width: "40px",
+                            width: "300px",
                             command: [
                                 {
                                     name: "view",
                                     text: "",
                                     iconClass: "view-template-button k-icon k-i-eye",
+                                    visible: function(dataItem) {
+                                        // Note: For some reason Kendo throw an "Uncaught Error: Invalid template" error when using an arrow function here, that's why this is a regular function.
+                                        return !dataItem.deleted;
+                                    },
                                     click: (event) =>
                                     {
                                         const item = $(event.delegateTarget).data("kendoGrid").dataItem(event.currentTarget.closest("tr"));
@@ -804,6 +819,15 @@ const moduleSettings = {
                                         let title = `Dynamic content "${item.title}" (${item.dynamicContentId}) of template "${item.templateNames[0]}" (${item.templateIds[0]})`;
                                         this.openPopupWindow(url, title);
                                     }
+                                },
+                                {
+                                    title: "&nbsp;",
+                                    width: "300px",
+                                    visible: function(dataItem) {
+                                        // Note: For some reason Kendo throw an "Uncaught Error: Invalid template" error when using an arrow function here, that's why this is a regular function.
+                                        return dataItem.deleted;
+                                    },
+                                    template: "Dit component is verwijderd met deze versie"
                                 }
                             ]
                         }
@@ -1075,7 +1099,7 @@ const moduleSettings = {
                 kendo.alert("Er is iets fout gegaan met het laden van de commit historie. Sluit a.u.b. deze module, open deze daarna opnieuw en probeer het vervolgens opnieuw. Of neem contact op als dat niet werkt.");
             }
         }
-        
+
         /**
          * Setup/initialize the grid with all reviews.
          */
@@ -1257,19 +1281,33 @@ const moduleSettings = {
                 columns: [
                     {field: "templateName", title: "Template"},
                     {field: "templateParentName", title: "Map"},
+                    {field: "version", title: "Versie", width: "75px"},
                     {
                         title: "&nbsp;",
-                        width: "150px",
+                        width: "300px",
                         command: [{
                             name: "open",
                             text: "Bekijk historie",
                             iconClass: "k-icon k-i-hyperlink-open",
+                            visible: function(dataItem) {
+                                // Note: For some reason Kendo throw an "Uncaught Error: Invalid template" error when using an arrow function here, that's why this is a regular function.
+                                return !dataItem.deleted;
+                            },
                             click: (event) => {
                                 const item = $(event.delegateTarget).data("kendoGrid").dataItem(event.currentTarget.closest("tr"));
                                 let url = `/Modules/Templates?templateId=${item.templateId}&InitialTab=history`;
                                 let title = `${item.templateType} template "${item.templateName}" (${item.templateId})`;
                                 this.openPopupWindow(url, title);
                             }
+                        },
+                        {
+                            title: "&nbsp;",
+                            width: "300px",
+                            visible: function(dataItem) {
+                                // Note: For some reason Kendo throw an "Uncaught Error: Invalid template" error when using an arrow function here, that's why this is a regular function.
+                                return dataItem.deleted;
+                            },
+                            template: "Deze template is verwijderd met deze commit"
                         }]
                     }
                 ],
@@ -1300,21 +1338,33 @@ const moduleSettings = {
                     {field: "templateNames", title: "Gekoppelde templates", template: "#= templateNames.join(', ') #"},
                     {field: "title", title: "Naam"},
                     {field: "component", title: "Component"},
+                    {field: "version", title: "Versie", width: "75px"},
                     {
                         title: "&nbsp;",
-                        width: "150px",
+                        width: "300px",
                         command: [{
                             name: "open",
                             text: "Bekijk historie",
                             iconClass: "k-icon k-i-hyperlink-open",
+                            visible: function(dataItem) {
+                                // Note: For some reason Kendo throw an "Uncaught Error: Invalid template" error when using an arrow function here, that's why this is a regular function.
+                                return !dataItem.deleted;
+                            },
                             click: (event) => {
                                 const item = $(event.delegateTarget).data("kendoGrid").dataItem(event.currentTarget.closest("tr"));
-                                for (let i = 0; i < item.templateIds.length; i++) {
-                                    let url = `/Modules/Templates?templateId=${item.templateIds[i]}&InitialTab=history`;
-                                    let title = `Template "${item.templateNames[i]}" (${item.templateIds[i]})`;
-                                    this.openPopupWindow(url, title, false);
-                                }
+                                let url = `/Modules/DynamicContent/${item.dynamicContentId}?templateId=${item.templateIds[0]}&InitialTab=history`;
+                                let title = `Dynamic content "${item.title}" (${item.dynamicContentId}) of template "${item.templateNames[0]}" (${item.templateIds[0]})`;
+                                this.openPopupWindow(url, title);
                             }
+                        },
+                        {
+                            title: "&nbsp;",
+                            width: "300px",
+                            visible: function(dataItem) {
+                                // Note: For some reason Kendo throw an "Uncaught Error: Invalid template" error when using an arrow function here, that's why this is a regular function.
+                                return dataItem.deleted;
+                            },
+                            template: "Dit component is verwijderd met deze commit"
                         }]
                     }
                 ],


### PR DESCRIPTION
* You can now clearly see if a template has been deleted when you're committing or reviewing.
* Fixed bug in query that caused it to sometimes have 1 result with null in all columns.
* When doing a review and opening the changes for a component, you will now only see the changes of that component, instead of all changes of the template that the component is linked to.
* Fixed problem that loader was hidden too early, before we were done loading everything.

There is no Asana ticket for this. I made these changes when making a presentation to present this functionality.