### PR TITLE
Prevent file download from unencrypted item IDs

### DIFF
--- a/Api/Modules/Files/Services/FilesService.cs
+++ b/Api/Modules/Files/Services/FilesService.cs
@@ -393,9 +393,19 @@ SELECT LAST_INSERT_ID() AS newId;";
                 throw new ArgumentNullException(nameof(encryptedItemId));
             }
 
-            if (!UInt64.TryParse(encryptedItemId, out var itemId))
+            ulong itemId;
+
+            try
             {
                 itemId = await wiserTenantsService.DecryptValue<ulong>(encryptedItemId, identity);
+            }
+            catch (FormatException)
+            {
+                return new ServiceResult<(string ContentType, byte[] Data, string Url)>()
+                {
+                    StatusCode = HttpStatusCode.BadRequest,
+                    ErrorMessage = $"Failed to decrypt item ID '{encryptedItemId}'."
+                };
             }
 
             if (fileId <= 0 && String.IsNullOrEmpty(propertyName))


### PR DESCRIPTION
Remove code to skip decrypting if a plain ID has been provided. Files are only allowed to be downloaded when using encrypted IDs.

https://app.asana.com/0/1205090868730163/1205887586007820