### PR TITLE
Give error when column are missing.

### DIFF
--- a/Api/Modules/Queries/Services/QueriesService.cs
+++ b/Api/Modules/Queries/Services/QueriesService.cs
@@ -339,6 +339,15 @@ DELETE FROM {WiserTableNames.WiserPermission} WHERE query_id = ?id AND query_id 
             {
                 return new ServiceResult<JToken>(result);
             }
+            
+            if (!dataTable.Columns.Contains("key") || !dataTable.Columns.Contains("value"))
+            {
+                return new ServiceResult<JToken>
+                {
+                    StatusCode = HttpStatusCode.BadRequest,
+                    ErrorMessage = "The query result does not contain the expected columns 'key' and 'value'."
+                };
+            }
 
             var combinedResult = new JObject();
 


### PR DESCRIPTION
If the query resutls are retrieved in JSON as key-value pair it will give an error that the columns are missing instead of an object reference exception.

https://app.asana.com/0/1205090868730163/1204870251660089