### PR TITLE
Increased MySQL command timeouts

### DIFF
--- a/Api/Modules/Grids/Services/GridsService.cs
+++ b/Api/Modules/Grids/Services/GridsService.cs
@@ -98,6 +98,7 @@ namespace Api.Modules.Grids.Services
             ClaimsIdentity identity)
         {
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
+            clientDatabaseConnection.SetCommandTimeout(600);
             var tenant = await wiserTenantsService.GetSingleAsync(identity);
             var encryptionKey = tenant.ModelObject.EncryptionKey;
             var itemId = wiserTenantsService.DecryptValue<ulong>(encryptedId, tenant.ModelObject);
@@ -2101,6 +2102,7 @@ namespace Api.Modules.Grids.Services
             ClaimsIdentity identity)
         {
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
+            clientDatabaseConnection.SetCommandTimeout(600);
             var tenant = await wiserTenantsService.GetSingleAsync(identity);
             var queryId = String.IsNullOrWhiteSpace(encryptedQueryId) ? 0 : wiserTenantsService.DecryptValue<int>(encryptedQueryId, tenant.ModelObject);
             var countQueryId = String.IsNullOrWhiteSpace(encryptedCountQueryId) ? 0 : wiserTenantsService.DecryptValue<int>(encryptedCountQueryId, tenant.ModelObject);

--- a/Api/Modules/Items/Services/ItemsService.cs
+++ b/Api/Modules/Items/Services/ItemsService.cs
@@ -125,7 +125,7 @@ namespace Api.Modules.Items.Services
                     whereClause.Add("item.title = ?title");
                     clientDatabaseConnection.AddParameter("title", filters.Title);
                 }
-                
+
                 if (!String.IsNullOrWhiteSpace(filters.EntityType))
                 {
                     whereClause.Add("item.entity_type = ?entityType");
@@ -817,6 +817,7 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
             }
 
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
+            clientDatabaseConnection.SetCommandTimeout(600);
             var userId = IdentityHelpers.GetWiserUserId(identity);
             var username = IdentityHelpers.GetUserName(identity, true);
             var itemId = await wiserTenantsService.DecryptValue<ulong>(encryptedId, identity);
@@ -915,6 +916,7 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
         public async Task<ServiceResult<ActionButtonResultModel>> ExecuteCustomQueryAsync(string encryptedId, int propertyId, Dictionary<string, object> extraParameters, string encryptedQueryId, ClaimsIdentity identity, ulong itemLinkId = 0)
         {
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
+            clientDatabaseConnection.SetCommandTimeout(600);
             var userId = IdentityHelpers.GetWiserUserId(identity);
             var username = IdentityHelpers.GetUserName(identity, true);
             var userEmailAddress = IdentityHelpers.GetEmailAddress(identity);


### PR DESCRIPTION
Since we've started using a different MySQL connector library, users are complaining that they're getting a lot more timeout errors. It seems that the new connector has a shorter timeout by default. I increased the timeout to 10 minutes for places where custom queries get executed (queries that are customer specific).

Asana ticket: https://app.asana.com/0/1182779092805226/1206751393097151