### PR TITLE
Fix missing versions when using dropdown to deploy

### DIFF
--- a/Api/Modules/Templates/Services/DynamicContentService.cs
+++ b/Api/Modules/Templates/Services/DynamicContentService.cs
@@ -258,6 +258,13 @@ namespace Api.Modules.Templates.Services
             {
                 throw new ArgumentException("The version is invalid");
             }
+            
+            // Create a new version of the dynamic content, so that any changes made after this will be done in the new version instead of the published one.
+            // Does not apply if the dynamic content was published to live within a branch.
+            if (String.IsNullOrWhiteSpace(branchDatabaseName))
+            {
+                await CreateNewVersionAsync(contentId, version);
+            }
 
             var newPublished = PublishedEnvironmentHelper.CalculateEnvironmentsToPublish(currentPublished, version, environment);
 

--- a/Api/Modules/Templates/Services/TemplatesService.cs
+++ b/Api/Modules/Templates/Services/TemplatesService.cs
@@ -1460,13 +1460,13 @@ LIMIT 1";
                         break;
                     }
                 }
+            }
 
-                // Create a new version of the template, so that any changes made after this will be done in the new version instead of the published one.
-                // Does not apply if the template was published to live within a branch.
-                if (String.IsNullOrWhiteSpace(branchDatabaseName))
-                {
-                    await CreateNewVersionAsync(template.TemplateId, version);
-                }
+            // Create a new version of the template, so that any changes made after this will be done in the new version instead of the published one.
+            // Does not apply if the template was published to live within a branch.
+            if (String.IsNullOrWhiteSpace(branchDatabaseName))
+            {
+                await CreateNewVersionAsync(templateId, version);
             }
 
             var newPublished = PublishedEnvironmentHelper.CalculateEnvironmentsToPublish(currentPublished, version, environment);


### PR DESCRIPTION
When a template or dynamic content was deployed using the dropdowns no new version was created. When committing to the same environment the check to create a new version would fail because the latest version was already on that environment.

This check is now always executed for templates, instead of only for live. For dynamic contents this has been added since it was missing in the first place.

https://app.asana.com/0/1205090868730163/1206632507560566