### PR TITLE
Fixed a syntax error of a duplicate BEGIN statement

### DIFF
--- a/Api/Core/Queries/WiserInstallation/CreateTriggers.sql
+++ b/Api/Core/Queries/WiserInstallation/CreateTriggers.sql
@@ -642,7 +642,6 @@ END;
 
 DROP TRIGGER IF EXISTS `DetailUpdate`;
 CREATE TRIGGER `DetailUpdate` AFTER UPDATE ON `wiser_itemdetail` FOR EACH ROW BEGIN
-BEGIN
     DECLARE oldValue MEDIUMTEXT;
     DECLARE newValue MEDIUMTEXT;
     DECLARE previousItemId BIGINT;


### PR DESCRIPTION
# Describe your changes

The create script contains a syntax error where there are two `BEGIN` statements with only one `END` statement.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I encountered this problem when I first installed Wiser locally. I removed the second `BEGIN` statement. This solved the issue and the script ran as expected.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch

# Related pull requests

_N/A_

# Link to Asana ticket

_N/A_
