### PR TITLE
Added close button to template development tab

### DIFF
--- a/FrontEnd/Modules/Templates/Scripts/Templates.js
+++ b/FrontEnd/Modules/Templates/Scripts/Templates.js
@@ -1163,6 +1163,7 @@ const moduleSettings = {
             $("#saveButton").kendoButton({
                 icon: "save"
             });
+            $("#closeButton").kendoButton();
 
             if (!this.branches || !this.branches.length) {
                 $(".branch-container").addClass("hidden");
@@ -2025,6 +2026,7 @@ const moduleSettings = {
         }
 
         bindDeploymentTabEvents() {
+            document.getElementById("closeButton").addEventListener("click", this.closeTemplate.bind(this));
             document.getElementById("saveButton").addEventListener("click", this.saveTemplate.bind(this));
             document.getElementById("saveAndDeployToTestButton").addEventListener("click", this.saveTemplate.bind(this, true));
             document.getElementById("deployToBranchButton").addEventListener("click", this.deployToBranch.bind(this, true));
@@ -2237,6 +2239,29 @@ const moduleSettings = {
             finally {
                 window.processing.removeProcess(process);
             }
+        }
+        
+        async closeTemplate() {
+            // check for unsaved changes
+            if (this.selectedId && !this.canUnloadTemplate()) {
+                try {
+                    await kendo.confirm("U heeft nog openstaande wijzigingen. Weet u zeker dat u door wilt gaan?");
+                } catch {
+                    // Abort if cancelled
+                    return;
+                }
+            }
+            // reset treeview selections
+            for (let index = 0; index < this.mainTreeView.length; index++) {
+                this.mainTreeView[index].select($());
+            }
+            // unload loaded template
+            this.loadTemplate(0);
+            this.selectedId = 0;
+            this.lastLoadedHistoryPartNumber = 0;
+            this.measurementsLoaded = false;
+            // enable add button
+            $("#addButton").toggleClass("hidden", false);
         }
 
         /**

--- a/FrontEnd/Modules/Templates/Views/Templates/Tabs/DevelopmentTab.cshtml
+++ b/FrontEnd/Modules/Templates/Views/Templates/Tabs/DevelopmentTab.cshtml
@@ -4,6 +4,7 @@
 @* ReSharper disable Mvc.PartialViewNotResolved *@
 <div class="formview full developmentContainer @Model.TemplateSettings.Type.ToString()Tab">
     <div class="settings-container">
+        <button id="closeButton" class="k-secondary closeButton" style="float: right; z-index: 10; margin: 5px; height: 30px;"><ins class="icon-line-close k-button-text"></ins></button>
         <partial name="Partials/ConnectedUsers"/>
 
         <partial name="Partials/PublishedEnvironments" model="@Model.TemplateSettings"/>


### PR DESCRIPTION
# Describe your changes

Added close button to template development tab that unloads the current template and enables the add button.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Local build tested locally with all template types.

# Checklist before requesting a review
- [X] I have reviewed and tested my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [X] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [X] I added new unit tests for my changes if applicable

# Related pull requests

none

# Link to Asana ticket

https://app.asana.com/0/1201027711166952/1205948424661382
