### PR TITLE
Fix for loading widget settings

### DIFF
--- a/Api/Modules/Templates/Helpers/TemplateHelpers.cs
+++ b/Api/Modules/Templates/Helpers/TemplateHelpers.cs
@@ -67,7 +67,9 @@ public class TemplateHelpers
                 RawLinkList = dataRow.Field<string>("linked_templates") ?? ""
             },
             PreLoadQuery = dataRow.Field<string>("pre_load_query"),
-            ReturnNotFoundWhenPreLoadQueryHasNoData = Convert.ToBoolean(dataRow["return_not_found_when_pre_load_query_has_no_data"])
+            ReturnNotFoundWhenPreLoadQueryHasNoData = Convert.ToBoolean(dataRow["return_not_found_when_pre_load_query_has_no_data"]),
+            WidgetContent = dataRow.Field<string>("widget_content") ?? "",
+            WidgetLocation = (PageWidgetLocations) Convert.ToInt32(dataRow["widget_location"])
         };
 
         if (dataTable.Columns.Contains("external_files_json"))

--- a/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
+++ b/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
@@ -1309,7 +1309,9 @@ ORDER BY parent8.ordering, parent7.ordering, parent6.ordering, parent5.ordering,
     template.is_scss_include_template,
     template.use_in_wiser_html_editors,
     template.pre_load_query,
-    template.return_not_found_when_pre_load_query_has_no_data
+    template.return_not_found_when_pre_load_query_has_no_data,
+    template.widget_content,
+    template.widget_location
 FROM {WiserTableNames.WiserTemplate} AS template
 LEFT JOIN {WiserTableNames.WiserTemplate} AS otherVersion ON otherVersion.template_id = template.template_id AND otherVersion.version > template.version
 LEFT JOIN {WiserTableNames.WiserTemplate} AS parent1 ON parent1.template_id = template.parent_id AND parent1.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = template.parent_id)


### PR DESCRIPTION
# Describe your changes

Fixed the loading of the widget content and widget location in templates.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested this with a template that had widget content and location set and confirmed that both settings were loaded after loading the template. Also confirmed that templates without those settings will still load properly.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

No Asana ticket, ran into this while working with widget content.