### PR TITLE
Fixed deploying MySQL routines

### DIFF
--- a/Api/Modules/Templates/Helpers/TemplateHelpers.cs
+++ b/Api/Modules/Templates/Helpers/TemplateHelpers.cs
@@ -72,6 +72,20 @@ public class TemplateHelpers
             WidgetLocation = (PageWidgetLocations) Convert.ToInt32(dataRow["widget_location"])
         };
 
+        // Set routine properties.
+        if (dataTable.Columns.Contains("routine_type"))
+        {
+            templateData.RoutineType = dataRow.Field<RoutineTypes>("routine_type");
+        }
+        if (dataTable.Columns.Contains("routine_parameters"))
+        {
+            templateData.RoutineParameters = dataRow.Field<string>("routine_parameters");
+        }
+        if (dataTable.Columns.Contains("routine_return_type"))
+        {
+            templateData.RoutineReturnType = dataRow.Field<string>("routine_return_type");
+        }
+
         if (dataTable.Columns.Contains("external_files_json"))
         {
             var jsonString = dataRow.Field<string>("external_files_json");


### PR DESCRIPTION
# Describe your changes

Trying to deploy a MySQL routine resulted in an error because the routine properties never got set. The `DataRowToTemplateSettingsModel` method has been updated so the routine properties get set, but only if the supplied `DataRow` actually has the required columns.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Used a debug build and tested the deploy functionality for a `FUNCTION` routine and confirmed that it now works as intended.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

[Asana ticket](https://app.asana.com/0/1201027711166952/1207299005229571)