### PR TITLE
Remove has-default-value when user changes input

### DIFF
--- a/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
+++ b/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
@@ -129,6 +129,8 @@ const moduleSettings = {
 
             this.initializeButtons();
             await this.loadComponentHistory();
+
+            this.initBindings();
             
             window.processing.removeProcess(process);
         }
@@ -165,6 +167,31 @@ const moduleSettings = {
                 }
                 lastScrollTop = elem.scrollTop <= 0 ? 0 : elem.scrollTop;
             }
+        }
+        
+        initBindings() {
+            const removeDefaultValue = function (event) {
+                let target = event.currentTarget;
+                let elemContainer = target.closest('.has-default-value');
+                elemContainer.classList.remove('has-default-value');
+                target.removeEventListener('change', removeDefaultValue);
+            }
+
+            document.querySelectorAll(".has-default-value button.k-spinner-increase").forEach(input => {
+                input.addEventListener('click', removeDefaultValue)
+            });
+
+            document.querySelectorAll(".has-default-value button.k-spinner-decrease").forEach(input => {
+                input.addEventListener('click', removeDefaultValue)
+            });
+            
+            document.querySelectorAll(".has-default-value input").forEach(input => {
+                input.addEventListener('change', removeDefaultValue)
+            });
+
+            document.querySelectorAll(".has-default-value textarea").forEach(input => {
+                input.addEventListener('change', removeDefaultValue)
+            })
         }
 
         /**
@@ -261,6 +288,7 @@ const moduleSettings = {
                 $("#DynamicContentTabPane").html(response);
                 this.initializeDynamicKendoComponents();
                 await this.transformCodeMirrorViews();
+                this.initBindings();
             } catch (exception) {
                 console.error(exception);
                 kendo.alert("Er is iets fout gegaan. Probeer het a.u.b. opnieuw");
@@ -657,8 +685,19 @@ const moduleSettings = {
                     mode: element.dataset.fieldType
                 });
 
+                codeMirrorInstance.on('change', this.onCodeMirrorChange);
+
                 $(element).data("CodeMirrorInstance", codeMirrorInstance);
             });
+        }
+        
+        onCodeMirrorChange(codeMirrorElement) {
+            const textarea = codeMirrorElement.getTextArea();
+            let elemContainer = textarea.closest('.has-default-value');
+            
+            if (elemContainer) {
+                elemContainer.classList.remove('has-default-value');
+            }
         }
 
         /**


### PR DESCRIPTION
# Describe your changes

Currently when you change the value of an input that is greyed out because its current value is the default value and you change the value it stays greyed out until its saved and reopened
This adds some event listeners to the input that stops the inputs from being greyed out when the value changes.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Opened different dynamic contents in different templates. I tested the following inputs: textboxes, checkboxes, numericinputs, codemirror inputs. 

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1201027711166952/1202879712279684/f
