### PR TITLE
Fixed HTML editors always having all tools

### DIFF
--- a/Api/Modules/Items/FieldTemplates/HTMLeditor.js
+++ b/Api/Modules/Items/FieldTemplates/HTMLeditor.js
@@ -142,7 +142,8 @@
         }
 
         const toolModes = allTools[toolName];
-        if (options.tools && options.tools.indexOf(toolName) === -1 && toolModes.indexOf(options.mode) === -1) {
+        // if this tool is manually added to the options OR is supposed to be in this editor mode, do not skip it
+        if (((options.tools && options.tools.indexOf(toolName) > -1) || toolModes.indexOf(options.mode) > -1) === false) {
             continue;
         }
 


### PR DESCRIPTION
# Describe your changes

Incorrect if-statement made HTML editors ignore the "mode" setting if no manual tools options were set.

## Type of change

Please check only ONE option.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Local build, tested with and without manual additional tools on wiserdemo test entity

# Checklist before requesting a review
- [X] I have reviewed and tested my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [X] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

none

# Link to Asana ticket

https://app.asana.com/0/1205090868730163/1207494284865152
