### PR TITLE
Added "view entire source" in template history diff fields

### DIFF
--- a/FrontEnd/Modules/Base/Scripts/Utils.js
+++ b/FrontEnd/Modules/Base/Scripts/Utils.js
@@ -1435,7 +1435,7 @@ export class Wiser {
             let field = fields[i];
             let oldValue = field.querySelector("span.oldValue")?.getAttribute("value");
             let newValue = field.querySelector("span.newValue")?.getAttribute("value");
-            const fieldName = field.getAttribute("field-name");
+            let fieldName = field.getAttribute("field-name");
             const dataType = field.getAttribute("data-type");
             switch (dataType) { // TemplateTypes enum
                 case "Html": // Html is saved without whitespace in the database, so we need to make it readable first
@@ -1446,6 +1446,9 @@ export class Wiser {
                     oldValue = !oldValue ? "" : oldValue;
                     newValue = !newValue ? "" : newValue;
             }
+            if (fieldName === "editorValue") {
+                fieldName = "Template";
+            }
 
             const diff = Diff.createTwoFilesPatch(fieldName, fieldName, oldValue, newValue);
             field.innerHTML = Diff2Html.html(diff, {
@@ -1453,8 +1456,31 @@ export class Wiser {
                 matching: "words",
                 outputFormat: "side-by-side"
             });
-
             field.classList.remove("diffField");
+
+            let header = field.querySelector("div.d2h-file-header");
+            let viewButton = document.createElement('button');
+            viewButton.setAttribute('style', "width:100px;");
+            viewButton.textContent = "Toon alles";
+            $(viewButton).kendoButton({
+                click: function() {
+                    const html = Diff2Html.html(Diff.createTwoFilesPatch(fieldName, fieldName, oldValue, newValue, undefined, undefined, {context: Number.MAX_SAFE_INTEGER}), {
+                        drawFileList: false,
+                        matching: "words",
+                        outputFormat: "side-by-side"
+                    });
+
+                    let fullViewWindow = $(`<div style="padding:10px;">${html}</div>`).kendoWindow({
+                        title: `"${fieldName}" field version difference`,
+                        iframe: true,
+                        actions: ["close"]
+                    }).data("kendoWindow");
+
+                    fullViewWindow.maximize().open();
+                }
+            });
+
+            header.appendChild(viewButton);
         }
     }
 }


### PR DESCRIPTION
# Describe your changes

Added button to view the entire contents of the template field in the diff sections of the template history tab. This opens a temporary kendo window containing another diff field.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Local build, works great with big and small template sources.

# Checklist before requesting a review
- [X] I have reviewed and tested my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [X] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

none

# Link to Asana ticket

https://app.asana.com/0/1205090868730163/1206889839994812
