### PR TITLE
Bugfix/history tableprefix

### DIFF
--- a/Api/Modules/Grids/Services/GridsService.cs
+++ b/Api/Modules/Grids/Services/GridsService.cs
@@ -293,9 +293,7 @@ namespace Api.Modules.Grids.Services
                                     FROM {WiserTableNames.WiserHistory} current
 	                                
                                     WHERE current.item_id=?itemid
-                                    # Item link IDs will also be saved in the column 'item_id'.
-                                    # To prevent showing the history of an item link with the same id as the currently opened item, don't get history with action = 'UPDATE_ITEMLINK'.
-                                    AND current.action <> 'UPDATE_ITEMLINK'
+                                    AND (tablename = '{tablePrefix}{WiserTableNames.WiserItem}' OR tablename = '{tablePrefix}{WiserTableNames.WiserItemDetail}')
                                     [if({{changedby_has_filter}}=1)]AND changed_by {{changedby_filter}}[endif]
                                     [if({{changedon_has_filter}}=1)]AND DATE(changed_on) {{changedon_filter}}[endif]
                                     [if({{field_has_filter}}=1)]AND field {{field_filter}}[endif]

--- a/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
@@ -1223,7 +1223,7 @@ const moduleSettings = {
                 };
 
                 const gridDataResult = await Wiser.api({
-                    url: `${this.base.settings.wiserApiRoot}items/${encodeURIComponent(itemId)}/entity-grids/history?mode=3&moduleId=${this.base.settings.moduleId}`,
+                    url: `${this.base.settings.wiserApiRoot}items/${encodeURIComponent(itemId)}/entity-grids/${this.settings.entityType}?mode=3&moduleId=${this.base.settings.moduleId}`,
                     method: "POST",
                     contentType: "application/json",
                     data: JSON.stringify(options)
@@ -1267,7 +1267,7 @@ const moduleSettings = {
                                     previousFilters = currentFilters;
 
                                     const newGridDataResult = await Wiser.api({
-                                        url: `${this.base.settings.wiserApiRoot}items/${encodeURIComponent(itemId)}/entity-grids/history?mode=3&moduleId=${this.base.settings.moduleId}`,
+                                        url: `${this.base.settings.wiserApiRoot}items/${encodeURIComponent(itemId)}/entity-grids/${this.settings.entityType}?mode=3&moduleId=${this.base.settings.moduleId}`,
                                         method: "POST",
                                         contentType: "application/json",
                                         data: JSON.stringify(transportOptions.data)


### PR DESCRIPTION
# Describe your changes

The history in Wiser showed the history solely on the item_id, however it is possibly for multiple items to have the same id due to table prefixes. This made it possible for the history overview of a single item to contain data from multiple items.

This change fixes this by adding a check for table name.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Locally ran Wiser, opened history overview of multiple items. In particular I opened the wiser_items mentioned in the Asana ticket to see if the history was now properly separated.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1201027711166952/1206886132896175/f
