### PR TITLE
Fixed issue that added_on and added_by did not contain a value for new tenants in the examples for configurators.

### DIFF
--- a/Api/Core/Queries/WiserInstallation/InsertInitialDataConfigurator.sql
+++ b/Api/Core/Queries/WiserInstallation/InsertInitialDataConfigurator.sql
@@ -200,18 +200,18 @@ INSERT INTO `wiser_itemdetail` (`item_id`, `key`, `value`) VALUES (@stepTwoOneId
 -- Templates
 -- Configurator dynamic content
 SET @newContentId = (SELECT IFNULL(MAX(`content_id`), 0) + 1 FROM `wiser_dynamic_content`);
-INSERT INTO `wiser_dynamic_content` (`content_id`, `settings`, `component`, `component_mode`, `version`, `title`, `changed_on`, `changed_by`, `published_environment`) VALUES (@newContentId, '{"ConfiguratorName":"ExampleConfigurator","ValuesCanContainDashes":false,"ProductsApiBaseUrl":"","ProductsApiGetProductsUrl":"","ProductsApiSalesPriceProperty":"","ProductsApiPurchasePriceProperty":"","ProductsApiFromPriceProperty":"","UserNeedsToBeLoggedIn":false,"HandleRequest":false,"EvaluateIfElseInTemplates":true,"RemoveUnknownVariables":true,"CachingMode":"0","CachingLocation":"0","CacheMinutes":0,"ComponentMode":"2"}', 'Configurator', 'Vue', 1, 'ExampleConfigurator', NOW(), 'Wiser', 1);
+INSERT INTO `wiser_dynamic_content` (`content_id`, `settings`, `component`, `component_mode`, `version`, `title`, `changed_on`, `changed_by`, `published_environment`, `added_on`, `added_by`) VALUES (@newContentId, '{"ConfiguratorName":"ExampleConfigurator","ValuesCanContainDashes":false,"ProductsApiBaseUrl":"","ProductsApiGetProductsUrl":"","ProductsApiSalesPriceProperty":"","ProductsApiPurchasePriceProperty":"","ProductsApiFromPriceProperty":"","UserNeedsToBeLoggedIn":false,"HandleRequest":false,"EvaluateIfElseInTemplates":true,"RemoveUnknownVariables":true,"CachingMode":"0","CachingLocation":"0","CacheMinutes":0,"ComponentMode":"2"}', 'Configurator', 'Vue', 1, 'ExampleConfigurator', NOW(), 'Wiser', 1, NOW(), 'Wiser');
 SET @configuratorDynamicContentId = (SELECT `content_id` FROM `wiser_dynamic_content` WHERE `id` = LAST_INSERT_ID());
 
 -- Configurator scripts folder
 SET @scriptsFolderTemplateId = (SELECT `template_id` FROM `wiser_template` WHERE `template_name` = 'JS');
 SET @newTemplateId = (SELECT IFNULL(MAX(`template_id`), 0) + 1 FROM `wiser_template`);
-INSERT INTO `wiser_template` (`parent_id`, `template_name`, `template_type`, `version`, `template_id`, `changed_on`, `changed_by`, `published_environment`) VALUES (@scriptsFolderTemplateId, 'Configurators', 7, 1, @newTemplateId, NOW(), 'Wiser', 1);
+INSERT INTO `wiser_template` (`parent_id`, `template_name`, `template_type`, `version`, `template_id`, `changed_on`, `changed_by`, `published_environment`, `added_on`, `added_by`) VALUES (@scriptsFolderTemplateId, 'Configurators', 7, 1, @newTemplateId, NOW(), 'Wiser', 1, NOW(), 'Wiser');
 SET @configuratorScriptsFolder = (SELECT `template_id` FROM `wiser_template` WHERE `id` = LAST_INSERT_ID());
 
 -- Configurator script template
 SET @newTemplateId = (SELECT IFNULL(MAX(`template_id`), 0) + 1 FROM `wiser_template`);
-INSERT INTO `wiser_template` (`parent_id`, `template_name`, `template_data`, `template_type`, `version`, `template_id`, `changed_on`, `changed_by`, `published_environment`) VALUES (@configuratorScriptsFolder, 'ExampleConfigurator', CONCAT(
+INSERT INTO `wiser_template` (`parent_id`, `template_name`, `template_data`, `template_type`, `version`, `template_id`, `changed_on`, `changed_by`, `published_environment`, `added_on`, `added_by`) VALUES (@configuratorScriptsFolder, 'ExampleConfigurator', CONCAT(
 'class ExampleConfigurator {
     constructor() {
         this.configurator = {};
@@ -237,18 +237,18 @@ INSERT INTO `wiser_template` (`parent_id`, `template_name`, `template_data`, `te
 }
 
 window.configurator = new ExampleConfigurator();'
-), 4, 1, @newTemplateId, NOW(), 'Wiser', 1);
+), 4, 1, @newTemplateId, NOW(), 'Wiser', 1, NOW(), 'Wiser');
 SET @configuratorScriptTemplateId = (SELECT `template_id` FROM `wiser_template` WHERE `id` = LAST_INSERT_ID());
 
 -- Configurator HTML folder
 SET @htmlFolderTemplateId = (SELECT `template_id` FROM `wiser_template` WHERE `template_name` = 'HTML');
 SET @newTemplateId = (SELECT IFNULL(MAX(`template_id`), 0) + 1 FROM `wiser_template`);
-INSERT INTO `wiser_template` (`parent_id`, `template_name`, `template_type`, `version`, `template_id`, `changed_on`, `changed_by`, `published_environment`) VALUES (@htmlFolderTemplateId, 'Configurators', 7, 1, @newTemplateId, NOW(), 'Wiser', 1);
+INSERT INTO `wiser_template` (`parent_id`, `template_name`, `template_type`, `version`, `template_id`, `changed_on`, `changed_by`, `published_environment`, `added_on`, `added_by`) VALUES (@htmlFolderTemplateId, 'Configurators', 7, 1, @newTemplateId, NOW(), 'Wiser', 1, NOW(), 'Wiser');
 SET @configuratorTemplateFolder = (SELECT `template_id` FROM `wiser_template` WHERE `id` = LAST_INSERT_ID());
 
 -- Configurator HTML template
 SET @newTemplateId = (SELECT IFNULL(MAX(`template_id`), 0) + 1 FROM `wiser_template`);
-INSERT INTO `wiser_template` (`parent_id`, `template_name`, `template_data`, `template_type`, `version`, `template_id`, `changed_on`, `changed_by`, `published_environment`, `linked_templates`) VALUES (@configuratorTemplateFolder, 'ExampleConfigurator', CONCAT('<div class="dynamic-content" content-id="', @configuratorDynamicContentId, '"><h2>ExampleConfigurator</h2></div>'), 1, 1, @newTemplateId, NOW(), 'Wiser', 1, @configuratorScriptTemplateId);
+INSERT INTO `wiser_template` (`parent_id`, `template_name`, `template_data`, `template_type`, `version`, `template_id`, `changed_on`, `changed_by`, `published_environment`, `linked_templates`, `added_on`, `added_by`) VALUES (@configuratorTemplateFolder, 'ExampleConfigurator', CONCAT('<div class="dynamic-content" content-id="', @configuratorDynamicContentId, '"><h2>ExampleConfigurator</h2></div>'), 1, 1, @newTemplateId, NOW(), 'Wiser', 1, @configuratorScriptTemplateId, NOW(), 'Wiser');
 SET @configuratorHtmlTemplateId = (SELECT `template_id` FROM `wiser_template` WHERE `id` = LAST_INSERT_ID());
 
 -- Connect configurator HTML template and dynamic content


### PR DESCRIPTION
# Describe your changes

Fixed issue that added_on and added_by did not contain a value for new tenants in the examples for configurators.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I tested this by executing the updated queries in a test database.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1205090868730163/1207527885769049