### PR TITLE
Fix get items endpoint when item has no properties

### DIFF
--- a/Api/Modules/Items/Services/ItemsService.cs
+++ b/Api/Modules/Items/Services/ItemsService.cs
@@ -286,6 +286,11 @@ namespace Api.Modules.Items.Services
                 var fields = String.IsNullOrWhiteSpace(fieldsJson) ? new List<DisplayItemDetailModel>() : JsonConvert.DeserializeObject<List<DisplayItemDetailModel>>(fieldsJson);
                 foreach (var field in fields)
                 {
+                    if (String.IsNullOrWhiteSpace(field.Key))
+                    {
+                        continue;
+                    }
+                
                     var name = field.DisplayName;
                     if (String.IsNullOrWhiteSpace(name) || !useFriendlyPropertyNames)
                     {


### PR DESCRIPTION
# Describe your changes

When items of an entity are requested that have no properties an empty property would be given that failed to be processed. This skips that key.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by requesting an entity type that has no properties and one that does.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1199995500457439/1205916497751759/