### PR TITLE
Feature/branch improve id mapping

### DIFF
--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -155,7 +155,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GeeksCoreLibrary" Version="4.2.14" />
+    <PackageReference Include="GeeksCoreLibrary" Version="4.2.16" />
     <PackageReference Include="Google.Cloud.Translation.V2" Version="3.4.0" />
     <PackageReference Include="GoogleAuthenticator" Version="3.2.0" />
     <PackageReference Include="IdentityServer4" Version="4.1.2" />

--- a/Api/Modules/Branches/Interfaces/IBranchesService.cs
+++ b/Api/Modules/Branches/Interfaces/IBranchesService.cs
@@ -83,5 +83,14 @@ namespace Api.Modules.Branches.Interfaces
         /// <param name="identity">The <see cref="ClaimsIdentity">ClaimsIdentity</see> of the authenticated user.</param>
         /// <param name="id">The ID of the branch that should be deleted.</param>
         Task<ServiceResult<bool>> DeleteAsync(ClaimsIdentity identity, int id);
+        
+        /// <summary>
+        /// Get the ID of a branch that is mapped to the main branch.
+        /// If <paramref name="idIsFromBranch"/> equals <see langword="false"/> then the ID is from the main branch and the ID of the branch will be returned.
+        /// </summary>
+        /// <param name="id">The ID to get the mapped value for.</param>
+        /// <param name="idIsFromBranch">Optional: If the ID being given is from the branch.</param>
+        /// <returns></returns>
+        Task<ServiceResult<ulong?>> GetMappedIdAsync(ulong id, bool idIsFromBranch = true);
     }
 }

--- a/Api/Modules/Items/Controllers/ItemsController.cs
+++ b/Api/Modules/Items/Controllers/ItemsController.cs
@@ -153,9 +153,9 @@ namespace Api.Modules.Items.Controllers
         [HttpPost]
         [ProducesResponseType(typeof(CreateItemResultModel), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<IActionResult> PostAsync(WiserItemModel item, [FromQuery]string parentId = null, [FromQuery]int linkType = 1)
+        public async Task<IActionResult> PostAsync(WiserItemModel item, [FromQuery]string parentId = null, [FromQuery]int linkType = 1, [FromQuery] bool alsoCreateInMainBranch = false)
         {
-            return (await itemsService.CreateAsync(item, (ClaimsIdentity)User.Identity, parentId, linkType)).GetHttpResponseMessage();
+            return (await itemsService.CreateAsync(item, (ClaimsIdentity)User.Identity, parentId, linkType, alsoCreateInMainBranch)).GetHttpResponseMessage();
         }
 
         /// <summary>

--- a/Api/Modules/Items/Interfaces/IItemsService.cs
+++ b/Api/Modules/Items/Interfaces/IItemsService.cs
@@ -62,8 +62,9 @@ namespace Api.Modules.Items.Interfaces
         /// <param name="identity">The identity of the authenticated user.</param>
         /// <param name="encryptedParentId">Optional: The encrypted ID of the parent to create this item under.</param>
         /// <param name="linkType">Optional: The link type of the link to the parent.</param>
+        /// <param name="alsoCreateInMainBranch">Optional: Whether to also create the item in the main branch. Default is <see langword="false"/>.</param>
         /// <returns>A CreateItemResultModel with information about the newly created item.</returns>
-        Task<ServiceResult<CreateItemResultModel>> CreateAsync(WiserItemModel item, ClaimsIdentity identity, string encryptedParentId = null, int linkType = 1);
+        Task<ServiceResult<CreateItemResultModel>> CreateAsync(WiserItemModel item, ClaimsIdentity identity, string encryptedParentId = null, int linkType = 1, bool alsoCreateInMainBranch = false);
 
         /// <summary>
         /// Updates an item.

--- a/Api/Modules/Items/Services/ItemsService.cs
+++ b/Api/Modules/Items/Services/ItemsService.cs
@@ -751,6 +751,12 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
                     // Set the environment on the branch. This will add an entry to the history to activate the item on production after a merge has been performed.
                     newItem.PublishedEnvironment = Environments.Development | Environments.Test | Environments.Acceptance | Environments.Live;
                     await wiserItemsService.UpdateAsync(newItem.Id, newItem, userId: userId, username: username, encryptionKey: encryptionKey, createNewTransaction: false, skipPermissionsCheck: true);
+                    
+                    // Add the mapping to the mappings table.
+                    await databaseHelpersService.CheckAndUpdateTablesAsync(new List<string> {WiserTableNames.WiserIdMappings});
+                    clientDatabaseConnection.AddParameter("tableName", $"{tablePrefix}{WiserTableNames.WiserItem}");
+                    clientDatabaseConnection.AddParameter("id", newItem.Id);
+                    await clientDatabaseConnection.ExecuteAsync($"INSERT INTO {WiserTableNames.WiserIdMappings} (table_name, our_id, production_id) VALUES (?tableName, ?id, ?id)");
                 }
                 else
                 {

--- a/FrontEnd/FrontEnd.csproj
+++ b/FrontEnd/FrontEnd.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GeeksCoreLibrary" Version="4.2.14" />
+    <PackageReference Include="GeeksCoreLibrary" Version="4.2.16" />
     <PackageReference Include="GoogleAuthenticator" Version="3.2.0" />
   </ItemGroup>
 

--- a/FrontEnd/Modules/Base/Scripts/Utils.js
+++ b/FrontEnd/Modules/Base/Scripts/Utils.js
@@ -1058,8 +1058,9 @@ export class Wiser {
      * @param {boolean} skipUpdate Optional: By default the updateItem function will be called after creating the item, to save the data of the item. Set this parameter to true if you want to skip that step (if you have no other data to save).
      * @param {number} moduleId Optional: The id of the module in which the item should be created.
      * @returns {Object<string, any>} An object with the properties 'itemId', 'icon' and 'workflowResult'.
+     * @param {bool} alsoCreateInMainBranch Optional: Whether or not to create the item in the main branch as well to match IDs for merging later.
      */
-    static async createItem(moduleSettings, entityType, parentId, name, linkTypeNumber, data = [], skipUpdate = false, moduleId = null) {
+    static async createItem(moduleSettings, entityType, parentId, name, linkTypeNumber, data = [], skipUpdate = false, moduleId = null, alsoCreateInMainBranch = false) {
         try {
             const newItem = {
                 entityType: entityType,
@@ -1068,8 +1069,9 @@ export class Wiser {
             };
 
             const parentIdUrlPart = parentId ? `&parentId=${encodeURIComponent(parentId)}` : "";
+            const alsoCreateInMainBranchPart = alsoCreateInMainBranch ? "&alsoCreateInMainBranch=true" : ""; // Only add parameter if it has been set.
             const createItemResult = await Wiser.api({
-                url: `${moduleSettings.wiserApiRoot}items?linkType=${linkTypeNumber || 0}${parentIdUrlPart}&isNewItem=true`,
+                url: `${moduleSettings.wiserApiRoot}items?linkType=${linkTypeNumber || 0}${parentIdUrlPart}&isNewItem=true${alsoCreateInMainBranchPart}`,
                 method: "POST",
                 contentType: "application/json",
                 dataType: "JSON",

--- a/FrontEnd/Modules/DynamicItems/Scripts/Dialogs.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Dialogs.js
@@ -37,6 +37,10 @@ export class Dialogs {
                 { text: "Opslaan", primary: true, action: (event) => this.createItem() }
             ]
         }).data("kendoDialog");
+        
+        if ((await window.parent.main.branchesService.isMainBranch()).data && this.newItemDialog.element.find("#alsoCreateInMainBranch").closest(".new-item-dialog-row").length > 0) {
+            this.newItemDialog.element.find("#alsoCreateInMainBranch").closest(".new-item-dialog-row")[0].classList.add("hidden");
+        }
 
         this.newItemDialog.element.find("#newItemNameField").keyup((event) => {
             if (!event.key || event.key.toLowerCase() !== "enter") {
@@ -164,6 +168,7 @@ export class Dialogs {
 
         await this.loadAvailableEntityTypesInDropDown(parentId);
 
+        this.newItemDialog.element.find("#alsoCreateInMainBranch").prop("checked", false);
         const newItemNameField = this.newItemDialog.element.find("#newItemNameField").val("");
 
         this.newItemDialog.element.data("parentId", parentId);
@@ -207,6 +212,7 @@ export class Dialogs {
         const parentId = options.parentId;
         let node = options.treeNode;
         const newName = $("#newItemNameField").val() || "";
+        const alsoCreateInMainBranch = this.newItemDialog.element.find("#alsoCreateInMainBranch").prop("checked") || false;
 
         if (!entityType) {
             kendo.alert("Kies eerst een entiteit-type.");
@@ -219,7 +225,7 @@ export class Dialogs {
         }
 
         // Create the item in database.
-        const createItemResult = await this.base.createItem(entityType, parentId, newName, options.linkTypeNumber, [], false, options.moduleId);
+        const createItemResult = await this.base.createItem(entityType, parentId, newName, options.linkTypeNumber, [], false, options.moduleId, alsoCreateInMainBranch);
         if (!createItemResult) {
             return;
         }

--- a/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
@@ -2040,9 +2040,10 @@ const moduleSettings = {
          * @param {any} data Optional: The data to save with the new item.
          * @returns {Object<string, any>} An object with the properties 'itemId', 'icon' and 'workflowResult'.
          * @param {number} moduleId Optional: The id of the module in which the item should be created.
+         * @param {bool} alsoCreateInMainBranch Optional: Whether or not to create the item in the main branch as well to match IDs for merging later.
          */
-        async createItem(entityType, parentId, name, linkTypeNumber, data = [], skipUpdate = false, moduleId = null) {
-            return Wiser.createItem(this.settings, entityType, parentId, name, linkTypeNumber, data, skipUpdate, moduleId);
+        async createItem(entityType, parentId, name, linkTypeNumber, data = [], skipUpdate = false, moduleId = null, alsoCreateInMainBranch = false) {
+            return Wiser.createItem(this.settings, entityType, parentId, name, linkTypeNumber, data, skipUpdate, moduleId, alsoCreateInMainBranch);
         }
 
         /**

--- a/FrontEnd/Modules/DynamicItems/Views/DynamicItems/Index.cshtml
+++ b/FrontEnd/Modules/DynamicItems/Views/DynamicItems/Index.cshtml
@@ -604,6 +604,11 @@
                 <input type="text" id="newItemNameField" class="textField k-input" />
             </span>
         </div>
+        <div class="new-item-dialog-row">
+            <span class="inline">
+                <label class="checkbox"><input type="checkbox" id="alsoCreateInMainBranch" class="textField k-input" /><span>Maak ook aan in hoofd branch</span></label>
+            </span>
+        </div>
     </script>
 
     <script id="userNormalInputParameterTemplate" type="text/x-kendo-template">

--- a/Wiser.Tests/Wiser.Tests.csproj
+++ b/Wiser.Tests/Wiser.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GeeksCoreLibrary" Version="4.2.14" />
+        <PackageReference Include="GeeksCoreLibrary" Version="4.2.16" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />


### PR DESCRIPTION
# Describe your changes

Added an option to create an item in a branch directly to both the branch as the main database and ensure they have the same ID. This is used for items that are hard to be mapped. The option is only shown in the Wiser interface when on a branch.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

This has been tested by creating items on the branch, both with and without having it created on the main database. And by creating items only on main. Afterwards performed a merge to check if the items that have been created from the branch in both databases are correctly updated in the main database.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Jira ticket ID

CON-275
