### PR TITLE
Save files in branch and main database when uploading to file manager on branch

### DIFF
--- a/Api/Modules/Branches/Interfaces/IBranchesService.cs
+++ b/Api/Modules/Branches/Interfaces/IBranchesService.cs
@@ -5,6 +5,7 @@ using Api.Core.Services;
 using Api.Modules.Branches.Models;
 using Api.Modules.Tenants.Models;
 using GeeksCoreLibrary.Modules.Branches.Models;
+using GeeksCoreLibrary.Modules.Databases.Interfaces;
 
 namespace Api.Modules.Branches.Interfaces
 {
@@ -91,6 +92,16 @@ namespace Api.Modules.Branches.Interfaces
         /// <param name="id">The ID to get the mapped value for.</param>
         /// <param name="idIsFromBranch">Optional: If the ID being given is from the branch.</param>
         /// <returns></returns>
-        Task<ServiceResult<ulong?>> GetMappedIdAsync(ulong id, bool idIsFromBranch = true);
+        Task<ulong?> GetMappedIdAsync(ulong id, bool idIsFromBranch = true);
+
+        /// <summary>
+        /// Generates a new ID for the specified table. This will get the highest number from both databases and add 1 to that number.
+        /// This is to make sure that the new ID can be created in both databases to match.
+        /// </summary>
+        /// <param name="tableName">The name of the table.</param>
+        /// <param name="mainDatabaseConnection">The connection to the main database.</param>
+        /// <param name="branchDatabase">The connection to the branch database.</param>
+        /// <returns>The new ID that should be used for the item in both databases.</returns>
+        Task<ulong> GenerateNewIdAsync(string tableName, IDatabaseConnection mainDatabaseConnection, IDatabaseConnection branchDatabase);
     }
 }

--- a/Api/Modules/Files/Services/FilesService.cs
+++ b/Api/Modules/Files/Services/FilesService.cs
@@ -10,6 +10,7 @@ using Api.Core.Enums;
 using Api.Core.Helpers;
 using Api.Core.Models;
 using Api.Core.Services;
+using Api.Modules.Branches.Interfaces;
 using Api.Modules.CloudFlare.Interfaces;
 using Api.Modules.Files.Interfaces;
 using Api.Modules.Files.Interfaces.Repository;
@@ -23,6 +24,7 @@ using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Core.Services;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MySqlConnector;
@@ -40,11 +42,13 @@ namespace Api.Modules.Files.Services
         private readonly IWiserItemsService wiserItemsService;
         private readonly ICloudFlareService cloudFlareService;
         private readonly IFilesRepository filesRepository;
+        private readonly IBranchesService branchesService;
+        private readonly IServiceProvider serviceProvider;
 
         /// <summary>
         /// Creates a new instance of <see cref="FilesService"/>.
         /// </summary>
-        public FilesService(IWiserTenantsService wiserTenantsService, ILogger<FilesService> logger, IDatabaseConnection databaseConnection, IWiserItemsService wiserItemsService, ICloudFlareService cloudFlareService, IFilesRepository filesRepository, IOptions<TinyPngSettings> tinyPngSettings)
+        public FilesService(IWiserTenantsService wiserTenantsService, ILogger<FilesService> logger, IDatabaseConnection databaseConnection, IWiserItemsService wiserItemsService, ICloudFlareService cloudFlareService, IFilesRepository filesRepository, IOptions<TinyPngSettings> tinyPngSettings, IBranchesService branchesService, IServiceProvider serviceProvider)
         {
             this.wiserTenantsService = wiserTenantsService;
             this.logger = logger;
@@ -52,6 +56,8 @@ namespace Api.Modules.Files.Services
             this.wiserItemsService = wiserItemsService;
             this.cloudFlareService = cloudFlareService;
             this.filesRepository = filesRepository;
+            this.branchesService = branchesService;
+            this.serviceProvider = serviceProvider;
 
             Tinify.Key ??= tinyPngSettings.Value.TinifyApiKey;
         }
@@ -313,42 +319,61 @@ namespace Api.Modules.Files.Services
             }
 
             var username = IdentityHelpers.GetUserName(identity, true);
-            databaseConnection.ClearParameters();
+            
+            var tenant = await wiserTenantsService.GetSingleAsync(identity);
+            if (branchesService.IsMainBranch(tenant.ModelObject).ModelObject || !propertyName.Equals("global_file"))
+            {
+                return await SaveToDatabaseAsync(identity, databaseConnection, username, itemId, itemLinkId, entityType, linkType, title, fileBytes, content, contentUrl, fileExtension, contentType, fileName, propertyName);
+            }
+            
+            using var scope = serviceProvider.CreateScope();
+            var mainDatabaseConnection = scope.ServiceProvider.GetRequiredService<IDatabaseConnection>();
+            var mainTenant = await wiserTenantsService.GetSingleAsync(tenant.ModelObject.TenantId, true);
+            var mainBranchConnectionString = wiserTenantsService.GenerateConnectionStringFromTenant(mainTenant.ModelObject);
+            await mainDatabaseConnection.ChangeConnectionStringsAsync(mainBranchConnectionString);
+            
+            await SaveToDatabaseAsync(identity, mainDatabaseConnection, username, itemId, itemLinkId, entityType, linkType, title, fileBytes, content, contentUrl, fileExtension, contentType, fileName, propertyName);
+            return await SaveToDatabaseAsync(identity, databaseConnection, username, itemId, itemLinkId, entityType, linkType, title, fileBytes, content, contentUrl, fileExtension, contentType, fileName, propertyName, false);
+        }
+
+        private async Task<ServiceResult<FileModel>> SaveToDatabaseAsync(ClaimsIdentity identity, IDatabaseConnection dbConnection, string username, ulong itemId, ulong itemLinkId, string entityType, int linkType, string title, byte[] fileBytes, byte[] content, string contentUrl, string fileExtension, string contentType, string fileName, string propertyName, bool saveHistory = true)
+        {
+            dbConnection.ClearParameters();
             var columnsForInsertQuery = new List<string> { "content_url", "content_type", "file_name", "extension", "added_by", "title", "property_name", "ordering" };
             var tablePrefix = "";
             if (itemLinkId > 0)
             {
                 tablePrefix = await wiserItemsService.GetTablePrefixForLinkAsync(linkType, entityType);
-                databaseConnection.ClearParameters();
-                databaseConnection.AddParameter("itemlink_id", itemLinkId);
+                dbConnection.ClearParameters();
+                dbConnection.AddParameter("itemlink_id", itemLinkId);
                 columnsForInsertQuery.Add("itemlink_id");
             }
             else if (itemId > 0)
             {
                 tablePrefix = await wiserItemsService.GetTablePrefixForEntityAsync(entityType);
-                databaseConnection.ClearParameters();
-                databaseConnection.AddParameter("item_id", itemId);
+                dbConnection.ClearParameters();
+                dbConnection.AddParameter("item_id", itemId);
                 columnsForInsertQuery.Add("item_id");
             }
             else
             {
-                databaseConnection.AddParameter("itemlink_id", 0);
-                databaseConnection.AddParameter("item_id", 0);
+                dbConnection.AddParameter("itemlink_id", 0);
+                dbConnection.AddParameter("item_id", 0);
             }
 
             if (content?.Length > 0)
             {
-                databaseConnection.AddParameter("content", content);
+                dbConnection.AddParameter("content", content);
                 columnsForInsertQuery.Add("content");
             }
 
-            databaseConnection.AddParameter("content_url", contentUrl);
-            databaseConnection.AddParameter("content_type", contentType);
-            databaseConnection.AddParameter("file_name", fileName);
-            databaseConnection.AddParameter("extension", Path.GetExtension(fileName));
-            databaseConnection.AddParameter("added_by", username ?? "");
-            databaseConnection.AddParameter("title", title ?? "");
-            databaseConnection.AddParameter("property_name", propertyName);
+            dbConnection.AddParameter("content_url", contentUrl);
+            dbConnection.AddParameter("content_type", contentType);
+            dbConnection.AddParameter("file_name", fileName);
+            dbConnection.AddParameter("extension", Path.GetExtension(fileName));
+            dbConnection.AddParameter("added_by", username ?? "");
+            dbConnection.AddParameter("title", title ?? "");
+            dbConnection.AddParameter("property_name", propertyName);
 
             var ordering = 1;
             var whereClause = itemLinkId > 0 ? "itemlink_id = ?itemlink_id" : "item_id = ?item_id";
@@ -356,18 +381,21 @@ namespace Api.Modules.Files.Services
 FROM {tablePrefix}{WiserTableNames.WiserItemFile}
 WHERE {whereClause}
 AND property_name = ?property_name";
-            var dataTable = await databaseConnection.GetAsync(query);
+            var dataTable = await dbConnection.GetAsync(query);
             if (dataTable.Rows.Count > 0)
             {
                 ordering = Convert.ToInt32(dataTable.Rows[0]["maxOrdering"]) + 1;
             }
-            databaseConnection.AddParameter("ordering", ordering);
+            dbConnection.AddParameter("ordering", ordering);
+            
+            dbConnection.AddParameter("saveHistoryGcl", saveHistory); // This is used in triggers.
 
-            query = $@"SET @_username = ?added_by;
+            query = $@"SET @saveHistory = ?saveHistoryGcl;
+SET @_username = ?added_by;
 INSERT INTO {tablePrefix}{WiserTableNames.WiserItemFile} ({String.Join(", ", columnsForInsertQuery)})
 VALUES ({String.Join(", ", columnsForInsertQuery.Select(x => $"?{x}"))});
 SELECT LAST_INSERT_ID() AS newId;";
-            var newItem = await databaseConnection.GetAsync(query);
+            var newItem = await dbConnection.GetAsync(query);
 
             var result = new FileModel
             {

--- a/FrontEnd/Modules/FileManager/Scripts/FileManager.js
+++ b/FrontEnd/Modules/FileManager/Scripts/FileManager.js
@@ -1037,7 +1037,7 @@ const moduleSettings = {
             try {
                 kendo.prompt("Vul een naam in").then((name) => {
                     // Using then instead of async/await, because kendo can't handle async events.
-                    Wiser.createItem(this.settings, "filedirectory", parentId, name, null, [], true).then((createItemResult) => {
+                    Wiser.createItem(this.settings, "filedirectory", parentId, name, null, [], true, null, true).then((createItemResult) => {
                         if (!createItemResult) {
                             kendo.alert("Er iets iets fout gegaan tijdens het aanmaken van de map. Probeer het a.u.b. opnieuw of neem contact op met ons.");
                         } else {
@@ -1049,7 +1049,7 @@ const moduleSettings = {
                 });
             } catch (exception) {
                 console.error(exception);
-                kendo.alert("Er iets iets fout gegaan tijdens het aanmaken van de map. Probeer het a.u.b. opnieuw of neem contact op met ons.");
+                kendo.alert("Er is iets fout gegaan tijdens het aanmaken van de map. Probeer het a.u.b. opnieuw of neem contact op met ons.");
             }
         }
 


### PR DESCRIPTION
# Describe your changes

When a file is uploaded through the file manager (global files) when the user is on a branch the file will be saved to the branch and main database under the same ID. This ensures after a merge all references are correctly and allows the preview to retrieve the image from the main website. The same applies for directories for the file manager module in Wiser.

Refactored some parts to reduce duplicate code.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by uploading images/files on the branch database in the file manager to see if they were created in both. Tested if the file was only saved in the main when uploaded there. And tested if an image for a Wiser item on a branch is only saved in the branch database.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Jira ticket ID

CON-280
