### PR TITLE
Disable dragging for virtual templates

### DIFF
--- a/FrontEnd/Modules/Templates/Scripts/Templates.js
+++ b/FrontEnd/Modules/Templates/Scripts/Templates.js
@@ -577,7 +577,13 @@ const moduleSettings = {
          */
         async onTreeViewDragStart(event) {
             // Virtual items cannot be dragged.
-            if (event.sourceNode.isVirtualItem) event.preventDefault();
+            const treeView = $(event.sourceNode).closest(".k-treeview-group").getKendoTreeView();
+            if (!treeView) {
+                return;
+            }
+            const dataItem = treeView.dataItem(event.sourceNode);
+
+            if (dataItem && dataItem.isVirtualItem) event.preventDefault();
         }
 
         /**
@@ -1060,7 +1066,6 @@ const moduleSettings = {
 
                 // Open dynamic content by double clicking on a row.
                 dynamicGridDiv.on("dblclick", "tr.k-state-selected", this.onDynamicContentOpenClick.bind(this));
-
             } catch (exception) {
                 console.error(exception);
                 kendo.alert(`Er is iets fout gegaan. Probeer het a.u.b. opnieuw of neem contact op met ons.<br>${exception.responseText || exception}`);


### PR DESCRIPTION
# Describe your changes

Some templates are "virtual" templates, and those were not supposed to be draggable in the treeview. However, the code that was trying to prevent the dragging didn't work. These changes fix that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested if virtual templates were prevented from being dragged, and if normal templates can still be dragged.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

[Asana ticket](https://app.asana.com/0/1201027711166952/1207832033914496)