### PR TITLE
Hide groups and tabs when all fields are hidden

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -491,15 +491,21 @@ export class Fields {
                         if (tab.classList.contains('overview-tab')) {
                             continue;
                         }
-
-                        const contentContainerId = tab.attributes['aria-controls'].value;
-
-                        const contentContainer = document.getElementById(contentContainerId);
-                        const groups = contentContainer.querySelectorAll(".item-group");
                         
                         let visibleItemFound = false;
+                        const contentContainerId = tab.attributes['aria-controls'].value;
+                        const contentContainer = document.getElementById(contentContainerId);
+                        let visibleItems = contentContainer.querySelectorAll('.item:not(.dependency-hidden)');
+                        if (visibleItems.length === 0) {
+                            tab.classList.add('hidden');
+                            continue;
+                        } else {
+                            tab.classList.remove('hidden');
+                        }
+                        
+                        const groups = contentContainer.querySelectorAll(".item-group");
                         for (let group of groups) {
-                            let visibleItems = group.querySelectorAll('.item:not(.dependency-hidden)');
+                            visibleItems = group.querySelectorAll('.item:not(.dependency-hidden)');
                             
                             if (visibleItems.length > 0) {
                                 visibleItemFound = true;
@@ -508,8 +514,6 @@ export class Fields {
                                 group.classList.add('dependency-hidden');
                             }
                         }
-
-                        tab.classList.toggle('hidden', !visibleItemFound);
                     }
                     
                     break;

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -485,13 +485,33 @@ export class Fields {
                             break;
                     }
 
-                    const fieldContainer = container.closest(".k-tabstrip").find(`[data-property-id='${dependency.propertyId}'].item`).toggleClass("dependency-hidden", !showElement);
-                    const tabContainer = fieldContainer.closest(".k-content");
-                    const allFields = tabContainer.find(".item");
-                    const visibleFields = allFields.filter(index => allFields[index].style.display !== "none");
-                    const tabIndex = tabContainer.index() - 1; // -1 because the first item in the DOM is always the tab strip (<ul>), we shouldn't count that one.
-                    tabStrip.tabGroup.children().eq(tabIndex).toggle(visibleFields.length > 0);
+                    container.closest(".k-tabstrip").find(`[data-property-id='${dependency.propertyId}'].item`).toggleClass("dependency-hidden", !showElement);
 
+                    for (let tab of tabStrip.items()) {
+                        if (tab.classList.contains('overview-tab')) {
+                            continue;
+                        }
+
+                        const contentContainerId = tab.attributes['aria-controls'].value;
+
+                        const contentContainer = document.getElementById(contentContainerId);
+                        const groups = contentContainer.querySelectorAll(".item-group");
+                        
+                        let visibleItemFound = false;
+                        for (let group of groups) {
+                            let visibleItems = group.querySelectorAll('.item:not(.dependency-hidden)');
+                            
+                            if (visibleItems.length > 0) {
+                                visibleItemFound = true;
+                                group.classList.remove('dependency-hidden');
+                            } else {
+                                group.classList.add('dependency-hidden');
+                            }
+                        }
+
+                        tab.classList.toggle('hidden', !visibleItemFound);
+                    }
+                    
                     break;
                 }
                 default:

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -492,10 +492,11 @@ export class Fields {
                             continue;
                         }
                         
-                        let visibleItemFound = false;
                         const contentContainerId = tab.attributes['aria-controls'].value;
                         const contentContainer = document.getElementById(contentContainerId);
                         let visibleItems = contentContainer.querySelectorAll('.item:not(.dependency-hidden)');
+                        
+                        // if there are no items the tab can be hidden and we don't have to check the group within the content pane 
                         if (visibleItems.length === 0) {
                             tab.classList.add('hidden');
                             continue;
@@ -503,12 +504,11 @@ export class Fields {
                             tab.classList.remove('hidden');
                         }
                         
+                        // Check if there are empty groups that should be hidden
                         const groups = contentContainer.querySelectorAll(".item-group");
                         for (let group of groups) {
                             visibleItems = group.querySelectorAll('.item:not(.dependency-hidden)');
-                            
                             if (visibleItems.length > 0) {
-                                visibleItemFound = true;
                                 group.classList.remove('dependency-hidden');
                             } else {
                                 group.classList.add('dependency-hidden');

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -488,20 +488,20 @@ export class Fields {
                     container.closest(".k-tabstrip").find(`[data-property-id='${dependency.propertyId}'].item`).toggleClass("dependency-hidden", !showElement);
 
                     for (let tab of tabStrip.items()) {
-                        if (tab.classList.contains('overview-tab')) {
+                        if (tab.classList.contains("overview-tab")) {
                             continue;
                         }
                         
-                        const contentContainerId = tab.attributes['aria-controls'].value;
+                        const contentContainerId = tab.attributes["aria-controls"].value;
                         const contentContainer = document.getElementById(contentContainerId);
                         let visibleItems = contentContainer.querySelectorAll('.item:not(.dependency-hidden)');
                         
                         // if there are no items the tab can be hidden and we don't have to check the group within the content pane 
                         if (visibleItems.length === 0) {
-                            tab.classList.add('hidden');
+                            tab.classList.add("hidden");
                             continue;
                         } else {
-                            tab.classList.remove('hidden');
+                            tab.classList.remove("hidden");
                         }
                         
                         // Check if there are empty groups that should be hidden
@@ -509,9 +509,9 @@ export class Fields {
                         for (let group of groups) {
                             visibleItems = group.querySelectorAll('.item:not(.dependency-hidden)');
                             if (visibleItems.length > 0) {
-                                group.classList.remove('dependency-hidden');
+                                group.classList.remove("dependency-hidden");
                             } else {
-                                group.classList.add('dependency-hidden');
+                                group.classList.add("dependency-hidden");
                             }
                         }
                     }

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -494,7 +494,7 @@ export class Fields {
                         
                         const contentContainerId = tab.attributes["aria-controls"].value;
                         const contentContainer = document.getElementById(contentContainerId);
-                        let visibleItems = contentContainer.querySelectorAll('.item:not(.dependency-hidden)');
+                        let visibleItems = contentContainer.querySelectorAll(".item:not(.dependency-hidden)");
                         
                         // if there are no items the tab can be hidden and we don't have to check the group within the content pane 
                         if (visibleItems.length === 0) {
@@ -507,7 +507,7 @@ export class Fields {
                         // Check if there are empty groups that should be hidden
                         const groups = contentContainer.querySelectorAll(".item-group");
                         for (let group of groups) {
-                            visibleItems = group.querySelectorAll('.item:not(.dependency-hidden)');
+                            visibleItems = group.querySelectorAll(".item:not(.dependency-hidden)");
                             if (visibleItems.length > 0) {
                                 group.classList.remove("dependency-hidden");
                             } else {


### PR DESCRIPTION
# Describe your changes

Now when due to dependencies all fields in a group or tab are hidden, the group or tab also gets hidden.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Set up a test item with a checkbox with dependant fields that were hidden when the checkbox is unchecked and tested the solution using this item.

When it worked with this I tested it with an item without groups.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1201027711166952/1207942309001520/f
