### PR TITLE
Several bug fixes in saving and loading grid filters in modules and s…

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -431,7 +431,6 @@ export class Grids {
                                 }
 
                                 transportOptions.data.firstLoad = this.mainGridForceRecount || currentFilters !== previousFilters;
-                                filtersChanged = currentFilters !== previousFilters;
                                 transportOptions.data.pageSize = transportOptions.data.page_size || transportOptions.data.pageSize;
                                 previousFilters = currentFilters;
                                 this.mainGridForceRecount = false;
@@ -482,6 +481,7 @@ export class Grids {
                     filterable: true,
                     allPages: true
                 },
+                filter: (event) => {filtersChanged = true;},
                 columnResize: (event) => this.saveGridViewColumnsState(`main_grid_columns_${this.base.settings.moduleId}`, event.sender),
                 columnReorder: (event) => this.saveGridViewColumnsState(`main_grid_columns_${this.base.settings.moduleId}`, event.sender),
                 columnHide: (event) => this.saveGridViewColumnsState(`main_grid_columns_${this.base.settings.moduleId}`, event.sender),


### PR DESCRIPTION
# Describe your changes

Several bug fixes in saving and loading grid filters in modules and sub-entities-grid:
- Clearing a filter value resulted in incorrect JSON, which caused the reload to fail and you always had an empty grid.
- Clearing a specific filter twice in a row resulted in a 500 error.
- In a module, saving filters only worked when server side filtering was used. This now also works with clients side filtering.
- Only load filters when keepFiltersState is true
- Code refactored

## Type of change

Please check only ONE option.

- [X] Bug fix (non-breaking changes which fixes issues)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Performed various actions that went wrong before implementing the changes. Checked that the problems have been resolved. Performed all possible actions regarding filtering in both sub-entities grids and in modules and found that no strange things happen anymore.

# Checklist before requesting a review
- [X] I have reviewed and tested my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [X] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [X] I added new unit tests for my changes if applicable

# Related pull requests

# Link to Asana ticket

https://app.asana.com/0/1201027711166952/1208070495893094
