### PR TITLE
Fix the environment of templates

### DIFF
--- a/Api/Modules/Templates/Services/TemplatesService.cs
+++ b/Api/Modules/Templates/Services/TemplatesService.cs
@@ -1497,8 +1497,8 @@ LIMIT 1";
             }
 
             // Create a new version of the template, so that any changes made after this will be done in the new version instead of the published one.
-            // Does not apply if the template was published to live within a branch.
-            if (branch == null)
+            // Does not apply if the template was published to live within a branch or if it was only deployed to the development environment.
+            if (branch == null && (environment & Environments.Development) != Environments.Development)
             {
                 await CreateNewVersionAsync(templateId, version);
             }

--- a/FrontEnd/Modules/Templates/Scripts/Templates.js
+++ b/FrontEnd/Modules/Templates/Scripts/Templates.js
@@ -2366,7 +2366,7 @@ const moduleSettings = {
                 window.popupNotification.show(`Template '${this.templateSettings.name}' is succesvol opgeslagen`, "info");
                 this.lastLoadedHistoryPartNumber = 0;
 
-                const version = (parseInt(document.querySelector(`#published-environments .version-test select.combo-select option:last-child`).value) || 0) + 1;
+                const version = parseInt(document.querySelector(`#published-environments .version-test select.combo-select option:last-child`).value) || 0;
                 await this.deployEnvironment(alsoDeployToTest === true ? "test" : "development", templateId, version);
 
                 if (reloadTemplateAfterSave) {


### PR DESCRIPTION
# Describe your changes

When running the WTS locally it would search for templates on the development environment. But when saving a template it would be set to no environment causing problems. This prevents that while still working correctly when deploying to the other environments.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by creating a new template, modifying/saving it and deploying it to different environments using the save and deploy to test, dropdowns and version control. In all cases the template create a new version at the correct moment and set the corrent environment.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1201027711166952/1207812386630781
