### PR TITLE
Feature/search small result expand

### DIFF
--- a/Api/Modules/Templates/Models/Template/TemplateTreeViewModel.cs
+++ b/Api/Modules/Templates/Models/Template/TemplateTreeViewModel.cs
@@ -10,12 +10,12 @@ namespace Api.Modules.Templates.Models.Template
         private bool isFolder;
         
         /// <summary>
-        /// Gets or sets the ID of the Template
+        /// Gets or sets the ID of the Template.
         /// </summary>
         public int TemplateId { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the Template
+        /// Gets or sets the name of the Template.
         /// </summary>
         public string TemplateName { get; set; }
 
@@ -41,32 +41,32 @@ namespace Api.Modules.Templates.Models.Template
         public bool HasChildren { get; set; }
         
         /// <summary>
-        /// Gets or sets the CSS class (for example the folder) which is collapsed
+        /// Gets or sets the CSS class (for example the folder) which is collapsed.
         /// </summary>
         public string CollapsedSpriteCssClass { get; set; }
         
         /// <summary>
-        /// Gets or sets the CSS class (for example the folder) which is expanded
+        /// Gets or sets the CSS class (for example the folder) which is expanded.
         /// </summary>
         public string ExpandedSpriteCssClass { get; set; }
         
         /// <summary>
-        /// Gets or sets the base CSS class (for example the folder) 
+        /// Gets or sets the base CSS class (for example the folder).
         /// </summary>
         public string SpriteCssClass { get; set; }
 
         /// <summary>
-        /// Gets or sets the settings for the Template
+        /// Gets or sets the settings for the Template.
         /// </summary>
         public TemplateSettingsModel TemplateSettings { get; set; }
 
         /// <summary>
-        /// Gets or sets a list of all child nodes this template contains
+        /// Gets or sets a list of all child nodes this template contains.
         /// </summary>
         public List<TemplateTreeViewModel> ChildNodes { get; set; }
         
         /// <summary>
-        /// Gets or sets the type of the template
+        /// Gets or sets the type of the template.
         /// </summary>
         public int TemplateType { get; set; }
 
@@ -80,7 +80,7 @@ namespace Api.Modules.Templates.Models.Template
         public bool IsVirtualItem { get; set; }
         
         /// <summary>
-        /// Whether the item should start as expanded in the treeview
+        /// Whether the item should start as expanded in the treeview.
         /// </summary>
         public bool Expanded { get; set; }
     }

--- a/Api/Modules/Templates/Models/Template/TemplateTreeViewModel.cs
+++ b/Api/Modules/Templates/Models/Template/TemplateTreeViewModel.cs
@@ -78,5 +78,10 @@ namespace Api.Modules.Templates.Models.Template
         /// This is typically meant for views, routines, and triggers that were retrieved from the database.
         /// </remarks>
         public bool IsVirtualItem { get; set; }
+        
+        /// <summary>
+        /// Whether the item should start as expanded in the treeview
+        /// </summary>
+        public bool Expanded { get; set; }
     }
 }

--- a/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
+++ b/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
@@ -988,11 +988,22 @@ LEFT JOIN {WiserTableNames.WiserTemplate} AS parent8 ON parent8.template_id = pa
                 allItems.Add(result);
             }
 
+            // if there are few items in the search result expand all items in the treeview
+            if (allItems.Count < 10)
+            {
+                allItems.ForEach(result => result.Expanded = true);
+            }
+
             void AddChildren(List<SearchResultModel> currentLevel)
             {
                 foreach (var result in currentLevel)
                 {
                     result.ChildNodes = allItems.Where(i => i.ParentId == result.TemplateId).Cast<TemplateTreeViewModel>().ToList();
+                    
+                    if (result.ChildNodes.Count == 1)
+                    {
+                        result.Expanded = true;
+                    }
                     AddChildren(result.ChildNodes.Cast<SearchResultModel>().ToList());
                 }
             }
@@ -1021,7 +1032,7 @@ AND otherVersion.id IS NULL";
             {
                 foreach (var result in currentLevel)
                 {
-                    if (!allItems.Any(i => i.TemplateId == result.TemplateId))
+                    if (allItems.All(i => i.TemplateId != result.TemplateId))
                     {
                         allItems.Add(result);
                     }
@@ -1048,6 +1059,7 @@ AND otherVersion.id IS NULL";
                 encryptedTemplatesAdded = true;
             }
 
+            
 
             if (!encryptedTemplatesAdded)
             {

--- a/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
+++ b/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
@@ -988,7 +988,7 @@ LEFT JOIN {WiserTableNames.WiserTemplate} AS parent8 ON parent8.template_id = pa
                 allItems.Add(result);
             }
 
-            // if there are few items in the search result expand all items in the treeview
+            // if there are few items in the search result expand all items in the treeview.
             if (allItems.Count < 10)
             {
                 allItems.ForEach(result => result.Expanded = true);

--- a/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
+++ b/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
@@ -1059,8 +1059,6 @@ AND otherVersion.id IS NULL";
                 encryptedTemplatesAdded = true;
             }
 
-            
-
             if (!encryptedTemplatesAdded)
             {
                 return results;


### PR DESCRIPTION
# Describe your changes

A small UX improvement for search results in the template module. Firstly it expands the treeview when there are only a few (less than 10) search results. Secondly it expands items with only a single child.

This saves the user from having to expand the items while keeping the treeview manageable.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Please describe how you tested your changes and how you confirmed this functionality is not a breaking change.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [ ] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1201027711166952/1206554736622739
