### PR TITLE
Set a newly created template always on dirty

### DIFF
--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -153,7 +153,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GeeksCoreLibrary" Version="4.2.21" />
+    <PackageReference Include="GeeksCoreLibrary" Version="4.2.23" />
     <PackageReference Include="Google.Cloud.Translation.V2" Version="3.4.0" />
     <PackageReference Include="GoogleAuthenticator" Version="3.2.0" />
     <PackageReference Include="IdentityServer4" Version="4.1.2" />

--- a/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
+++ b/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
@@ -1075,8 +1075,8 @@ AND otherVersion.id IS NULL";
             clientDatabaseConnection.AddParameter("editorValue", editorValue);
 
             var dataTable = await clientDatabaseConnection.GetAsync(@$"SET @id = (SELECT MAX(template_id)+1 FROM {WiserTableNames.WiserTemplate});
-INSERT INTO {WiserTableNames.WiserTemplate} (parent_id, template_name, template_type, version, template_id, added_on, added_by, changed_on, changed_by, published_environment, ordering, template_data, cache_minutes)
-VALUES (?parent, ?name, ?type, 1, @id, ?now, ?username, ?now, ?username, 1, ?ordering, ?editorValue, -1);
+INSERT INTO {WiserTableNames.WiserTemplate} (parent_id, template_name, template_type, version, template_id, added_on, added_by, changed_on, changed_by, published_environment, ordering, template_data, cache_minutes, is_dirty)
+VALUES (?parent, ?name, ?type, 1, @id, ?now, ?username, ?now, ?username, 1, ?ordering, ?editorValue, -1, TRUE);
 SELECT @id;");
 
             return Convert.ToInt32(dataTable.Rows[0]["@id"]);

--- a/FrontEnd/FrontEnd.csproj
+++ b/FrontEnd/FrontEnd.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GeeksCoreLibrary" Version="4.2.21" />
+    <PackageReference Include="GeeksCoreLibrary" Version="4.2.23" />
     <PackageReference Include="GoogleAuthenticator" Version="3.2.0" />
   </ItemGroup>
 

--- a/Wiser.Tests/Wiser.Tests.csproj
+++ b/Wiser.Tests/Wiser.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GeeksCoreLibrary" Version="4.2.21" />
+        <PackageReference Include="GeeksCoreLibrary" Version="4.2.23" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />


### PR DESCRIPTION
# Describe your changes

A new template would never be shown in the verison control until it has been saved at least once. Now new templates will be shown to reduce confusion.

And GCL updated

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by creating a new template and see if it is in the version control. And check when a new version is made this is not yet reflected in version control.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1201027711166952/1208376046799513
