### PR TITLE
Fix race condition for the branch merge window

### DIFF
--- a/FrontEnd/Core/Scripts/main.js
+++ b/FrontEnd/Core/Scripts/main.js
@@ -1164,16 +1164,13 @@ class Main {
                 },
 
                 async onWiserMergeBranchPromptOpen(sender) {
-                    await this.getEntitiesForBranches();
-                    await this.getLinkTypesForBranches();
-
                     if (this.branches && this.branches.length > 0) {
+                        await this.onSelectedBranchChange(this.branches[0].id);
                         this.branchMergeSettings.selectedBranch = this.branches[0];
-                        this.onSelectedBranchChange(this.branches[0].id);
                     }
                     else if (!this.isMainBranch) {
                         // If this is not the main branch, you can only synchronise the changes of the current branch, so get the changes immediately.
-                        this.onSelectedBranchChange();
+                        await this.onSelectedBranchChange();
                     }
                 },
 


### PR DESCRIPTION
# Describe your changes

When the selected branch is set the rendering would start. Due to a race condition data could not be found while rendering the front-end. By changing the order and awaiting the async function the race condition is gone. This also resulted in two function calls to be able to be removed so they are only called within the `onSelectedBranchChange` function.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by checking if after the changes the window correctly opened without error.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

N/A
