### PR TITLE
Bugfix in wiser_item table definition. Module id must be int, because…

### DIFF
--- a/Api/Core/Queries/WiserInstallation/CreateTables.sql
+++ b/Api/Core/Queries/WiserInstallation/CreateTables.sql
@@ -161,7 +161,7 @@ CREATE TABLE IF NOT EXISTS `wiser_item`  (
   `ordering` mediumint NOT NULL DEFAULT 0,
   `unique_uuid` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
   `entity_type` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
-  `moduleid` mediumint NOT NULL DEFAULT 0,
+  `moduleid` int NOT NULL DEFAULT 0,
   `published_environment` mediumint NOT NULL DEFAULT 15 COMMENT 'Bitwise, 0 = hidden, 1 = development, 2 = test, 4 = acceptance, 8 = live',
   `readonly` tinyint NOT NULL DEFAULT 0,
   `title` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',


### PR DESCRIPTION
# Describe your changes

Bugfix in wiser_item table definition. The module_id column should be int, because the id column in wiser_module is also int.

## Type of change

Please check only ONE option.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Not

# Checklist before requesting a review
- [X] I have reviewed and tested my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [X] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [X] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

N/A
