### PR TITLE
Add support for getting latest or earliest file when merging pdfs

### DIFF
--- a/Api/Modules/Files/Interfaces/IFilesService.cs
+++ b/Api/Modules/Files/Interfaces/IFilesService.cs
@@ -69,8 +69,10 @@ namespace Api.Modules.Files.Interfaces
         /// <param name="itemLinkId">Optional: If the file should be added to a link between two items, instead of an item, enter the ID of that link here.</param>
         /// <param name="entityType">Optional: When uploading a file for an item that has a dedicated table, enter the entity type name here so that we can see which table we need to add the file to.</param>
         /// <param name="linkType">Optional: When uploading a file for an item link that has a dedicated table, enter the link type here so that we can see which table we need to add the file to.</param>
+        /// <param name="propertyName">Optional: Used together with the itemId or itemLinkId to get the file</param>
+        /// <param name="selectionOption">Optional: Used to determine which of the files will be returned if an item has multiple.</param>
         /// <returns>The content type, contents and URL of the file.</returns>
-        Task<ServiceResult<(string ContentType, byte[] Data, string Url)>> GetAsync(ulong itemId, int fileId, ClaimsIdentity identity, ulong itemLinkId, string entityType = null, int linkType = 0, string propertyName = null);
+        Task<ServiceResult<(string ContentType, byte[] Data, string Url)>> GetAsync(ulong itemId, int fileId, ClaimsIdentity identity, ulong itemLinkId, string entityType = null, int linkType = 0, string propertyName = null, SelectionOptions selectionOption = SelectionOptions.None);
 
         /// <summary>
         /// Deletes a file.

--- a/Api/Modules/Files/Models/SelectionOptions.cs
+++ b/Api/Modules/Files/Models/SelectionOptions.cs
@@ -1,11 +1,20 @@
 namespace Api.Modules.Files.Models;
 
 /// <summary>
-/// 
+/// Used to determine which file should be selected if there are multiple options.
 /// </summary>
 public enum SelectionOptions
 {
+    /// <summary>
+    /// Indicates that it doesn't matter which file gets returned.
+    /// </summary>
     None,
-    Earliest,
-    Latest
+    /// <summary>
+    /// Gets the oldest file.
+    /// </summary>
+    Oldest,
+    /// <summary>
+    /// Gets the newest file.
+    /// </summary>
+    Newest
 }

--- a/Api/Modules/Files/Models/SelectionOptions.cs
+++ b/Api/Modules/Files/Models/SelectionOptions.cs
@@ -1,0 +1,11 @@
+namespace Api.Modules.Files.Models;
+
+/// <summary>
+/// 
+/// </summary>
+public enum SelectionOptions
+{
+    None,
+    Earliest,
+    Latest
+}

--- a/Api/Modules/Files/Services/FilesService.cs
+++ b/Api/Modules/Files/Services/FilesService.cs
@@ -523,8 +523,8 @@ SELECT {(fileId > 0 ? "?id" :  "LAST_INSERT_ID()")} AS newId;";
 
             var sortPart = selectionOption switch
             {
-                SelectionOptions.Earliest => "ORDER BY added_on ASC",
-                SelectionOptions.Latest => "ORDER BY added_on DESC",
+                SelectionOptions.Oldest => "ORDER BY added_on ASC",
+                SelectionOptions.Newest => "ORDER BY added_on DESC",
                 SelectionOptions.None => String.Empty,
                 _ => throw new NotImplementedException($"selectionOptions {selectionOption.ToString()} has not yet been implemented into FileService.GetAsync")
             };
@@ -574,11 +574,12 @@ SELECT {(fileId > 0 ? "?id" :  "LAST_INSERT_ID()")} AS newId;";
             }
 
             if (ftpSettings.Any())
-            {var ftp = ftpSettings.First();
-            if (ftp.Mode == FtpModes.Sftp)
             {
-                throw new NotImplementedException("SFTP is not yet supported");
-            }
+                var ftp = ftpSettings.First();
+                if (ftp.Mode == FtpModes.Sftp)
+                {
+                    throw new NotImplementedException("SFTP is not yet supported");
+                }
 
                 // Get the object used to communicate with the server.
                 var fullFtpLocation = $"ftp://{ftp.Host}{contentUrl}";

--- a/Api/Modules/Pdfs/Controllers/PdfsController.cs
+++ b/Api/Modules/Pdfs/Controllers/PdfsController.cs
@@ -72,7 +72,7 @@ namespace Api.Modules.Pdfs.Controllers
         [Produces(MediaTypeNames.Application.Pdf)]
         public async Task<IActionResult> MergePdfFilesAsync(MergePdfModel data)
         {
-            var mergedPdfResult = await pdfsService.MergePdfFilesAsync((ClaimsIdentity)User.Identity, data.EncryptedItemIdsList, data.PropertyNames, data.EntityType);
+            var mergedPdfResult = await pdfsService.MergePdfFilesAsync((ClaimsIdentity)User.Identity, data.EncryptedItemIdsList, data.PropertyNames, data.EntityType, data.FileSelection);
             return File(mergedPdfResult.ModelObject, "application/pdf");
         }
     }

--- a/Api/Modules/Pdfs/Interfaces/IPdfsService.cs
+++ b/Api/Modules/Pdfs/Interfaces/IPdfsService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Security.Claims;
 using System.Threading.Tasks;
 using Api.Core.Services;
+using Api.Modules.Files.Models;
 using GeeksCoreLibrary.Modules.GclConverters.Models;
 using Microsoft.AspNetCore.Mvc;
 
@@ -30,10 +31,12 @@ namespace Api.Modules.Pdfs.Interfaces
         /// <summary>
         /// Download and merge all pdf files
         /// </summary>
+        /// <param name="identity">The identity of the authenticated user.</param>
         /// <param name="encryptedItemIdsList">comma separted list of encrypted item-ids</param>
         /// <param name="propertyNames">the property name of te files that must be merged </param>
         /// <param name="entityType">the entitytype of the entity of the ID's</param>
+        /// <param name="selectionOptions">Used to determine which of the files will be returned if an item has multiple.</param>
         /// <returns>The location of the HTML file on the server.</returns>
-        Task<ServiceResult<byte[]>> MergePdfFilesAsync(ClaimsIdentity identity, string[] encryptedItemIdsList, string[] propertyNames, string entityType);
+        Task<ServiceResult<byte[]>> MergePdfFilesAsync(ClaimsIdentity identity, string[] encryptedItemIdsList, string[] propertyNames, string entityType, SelectionOptions selectionOptions = SelectionOptions.None);
     }
 }

--- a/Api/Modules/Pdfs/Models/MergePdfModel.cs
+++ b/Api/Modules/Pdfs/Models/MergePdfModel.cs
@@ -1,3 +1,5 @@
+using Api.Modules.Files.Models;
+
 namespace Api.Modules.Pdfs.Models;
 
 /// <summary>
@@ -19,4 +21,10 @@ public class MergePdfModel
     /// Gets or sets the property name of the files to retreive, this can be a comma-separated list
     /// </summary>
     public string[] PropertyNames { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the selection options used for the merge
+    /// With this you can determine which of the file gets used if an item has multiple
+    /// </summary>
+    public SelectionOptions FileSelection { get; set; } = SelectionOptions.None;
 }

--- a/Api/Modules/Pdfs/Services/PdfsService.cs
+++ b/Api/Modules/Pdfs/Services/PdfsService.cs
@@ -7,6 +7,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Api.Core.Services;
 using Api.Modules.Files.Interfaces;
+using Api.Modules.Files.Models;
 using Api.Modules.Pdfs.Interfaces;
 using Api.Modules.Tenants.Interfaces;
 using EvoPdf;
@@ -93,7 +94,7 @@ namespace Api.Modules.Pdfs.Services
         }
 
         /// <inheritdoc />
-        public async Task<ServiceResult<byte[]>> MergePdfFilesAsync(ClaimsIdentity identity, string[] encryptedItemIdsList, string[] propertyNames, string entityType)
+        public async Task<ServiceResult<byte[]>> MergePdfFilesAsync(ClaimsIdentity identity, string[] encryptedItemIdsList, string[] propertyNames, string entityType, SelectionOptions selectionOptions = SelectionOptions.None)
         {
             Document mergeResultPdfDocument = null;
 
@@ -104,7 +105,7 @@ namespace Api.Modules.Pdfs.Services
 
                 foreach (var propertyName in propertyNames)
                 {
-                    var pdfFile = await filesService.GetAsync(itemId, 0, identity, 0, entityType, propertyName:propertyName);
+                    var pdfFile = await filesService.GetAsync(itemId, 0, identity, 0, entityType, propertyName: propertyName, selectionOption: selectionOptions);
                     var pdfStream = new MemoryStream();
                     // Check if the PDF must be downloaded first
                     if (!String.IsNullOrWhiteSpace(pdfFile.ModelObject.Url))

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -2061,7 +2061,9 @@ export class Fields {
                                 body: JSON.stringify({
                                     encryptedItemIdsList:encryptedIds,
                                     entityType:action.entityType || "",
-                                    propertyNames:action.propertyNames})
+                                    propertyNames:action.propertyNames,
+                                    fileSelection:action.fileSelection
+                                })
                             });
                             await Misc.downloadFile(pdfResult, action.fileName || "mergedpdf.pdf");
                         }


### PR DESCRIPTION
# Describe your changes

Adds an option to the merge PDF functionality to get the newest or oldest files of an item.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Used the mergeFile action on items that already has previous generated PDF linked to get a merge of PDFs generated in a previous action.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1201394730777422/1208848056082229/f
