### PR TITLE
Remove some nuget packages that are no longer used

### DIFF
--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -164,8 +164,6 @@
     <PackageReference Include="JavaScriptEngineSwitcher.Extensions.MsDependencyInjection" Version="3.24.1" />
     <PackageReference Include="LibSassHost" Version="1.5.0" />
     <PackageReference Include="LibSassHost.Native.win-x64" Version="1.5.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.18" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.7.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.7.1" />
     <PackageReference Include="NUglify" Version="1.21.9" />
     <PackageReference Include="OpenIddict.AspNetCore" Version="5.8.0" />


### PR DESCRIPTION
# Describe your changes

Removes 2 packages that are no longer used.

- Microsoft.AspNetCore.Authentication.JwtBearer is not used because OpenIddict directly handles the authentication and validation of the JWT tokens now.
- Microsoft.IdentityModel.Protocols.OpenIdConnect was added during implementation of OpenIddict but ended up not being used.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Ran Wiser and logged in

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

N/A