### PR TITLE
Don't show database migration alert on unauthorized

### DIFF
--- a/FrontEnd/Core/Scripts/shared/databases.service.js
+++ b/FrontEnd/Core/Scripts/shared/databases.service.js
@@ -6,7 +6,7 @@ export default class DatabasesService extends BaseService {
             await this.base.api.put(`/api/v3/database/tenant-migrations`);
         } catch (exception) {
             if (exception.response.status === 401) {
-                console.warn("User is unauthorized to do tenant migrations.", exception);
+                console.warn("User is unauthorized to do database migrations.", exception);
             } else {
                 console.error("Error while executing database migrations", exception);
                 alert("Er is iets fout gegaan tijdens het uitvoeren van de database migraties. Ververs a.u.b. de pagina om het opnieuw te proberen, of neem contact op met de beheerder.");

--- a/FrontEnd/Core/Scripts/shared/databases.service.js
+++ b/FrontEnd/Core/Scripts/shared/databases.service.js
@@ -5,8 +5,12 @@ export default class DatabasesService extends BaseService {
         try {
             await this.base.api.put(`/api/v3/database/tenant-migrations`);
         } catch (exception) {
-            console.error("Error while executing database migrations", exception);
-            alert("Er is iets fout gegaan tijdens het uitvoeren van de database migraties. Ververs a.u.b. de pagina om het opnieuw te proberen, of neem contact op met de beheerder.");
+            if (exception.response.status === 401) {
+                console.warn("User is unauthorized to do tenant migrations.", exception);
+            } else {
+                console.error("Error while executing database migrations", exception);
+                alert("Er is iets fout gegaan tijdens het uitvoeren van de database migraties. Ververs a.u.b. de pagina om het opnieuw te proberen, of neem contact op met de beheerder.");
+            }
         }
     }
 }


### PR DESCRIPTION
# Describe your changes

When the user was unauthorized to do database migration, for example due to access token and refresh token being expired.
The user would get an alert that data migrations went wrong and then be redirected to the login. This is confusing for the end user so this adds a check for unauthorized so that no alert gets shown in these scenarios.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Added tokens that would be rejected into localStorage and refreshed the page.  

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

N/A
