### PR TITLE
Fix selectionOption when merging PDFs

### DIFF
--- a/Api/Modules/Pdfs/Services/PdfsService.cs
+++ b/Api/Modules/Pdfs/Services/PdfsService.cs
@@ -103,7 +103,7 @@ namespace Api.Modules.Pdfs.Services
 
                 foreach (var propertyName in propertyNames)
                 {
-                    var pdfFile = (await filesService.GetAsync(itemId, 0, identity, 0, entityType, propertyName:propertyName)).ModelObject;
+                    var pdfFile = (await filesService.GetAsync(itemId, 0, identity, 0, entityType, propertyName:propertyName, selectionOption: selectionOptions)).ModelObject;
                     using var pdfStream = new MemoryStream();
 
                     // Check if the PDF must be downloaded first.


### PR DESCRIPTION
# Describe your changes

Because the selectionOptions weren't passed to the file service you the parameter did nothing.

I think this got removed when merging the changes that added the selectionOption and rewriting the merge to use PdfSharp since both of these were done recently.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Merged PDFs on an item that already had other PDFs linked, getting the latest, and checking if I really got the latest.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1201394730777422/1208848056082229/f
