### PR TITLE
ParentId may be zero

### DIFF
--- a/Api/Modules/Items/Services/ItemsService.cs
+++ b/Api/Modules/Items/Services/ItemsService.cs
@@ -337,16 +337,7 @@ namespace Api.Modules.Items.Services
                     ErrorMessage = "Id must be greater than zero."
                 };
             }
-
-            if (parentId == 0)
-            {
-                return new ServiceResult<WiserItemDuplicationResultModel>
-                {
-                    StatusCode = HttpStatusCode.BadRequest,
-                    ErrorMessage = "ParentId must be greater than zero."
-                };
-            }
-
+     
             await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
             var username = IdentityHelpers.GetUserName(identity, true);
             var tenant = await wiserTenantsService.GetSingleAsync(identity);


### PR DESCRIPTION
# Describe your changes

While checking another issue related to item duplication i ran into a problem with duplicating configurators that were at the root (parent id zero), this was added 2 months ago but after investigating i learned that this check is not needed, parents may be zero in this case. the input variable is unsigned so there is also no need to check for negative ids, this check can be removed completely 

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

ran it on wiserdemo.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests
N/A

# Link to Asana ticket
No Asana ticket for this.
