### PR TITLE
change errorcode checking for re-try to use casted values in mysqlconection

### DIFF
--- a/Api/Core/Services/ClientDatabaseConnection.cs
+++ b/Api/Core/Services/ClientDatabaseConnection.cs
@@ -319,7 +319,7 @@ namespace Api.Core.Services
 
                 // If we're not in a transaction, retry the query if it's a deadlock.
                 var errorCode = (MySqlErrorCode)mySqlException.Number;
-                if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains( errorCode ))
+                if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(errorCode))
                 {
                     Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
                     return await ExecuteAsync(query, retryCount + 1, useWritingConnectionIfAvailable, cleanUp);

--- a/Api/Core/Services/ClientDatabaseConnection.cs
+++ b/Api/Core/Services/ClientDatabaseConnection.cs
@@ -235,7 +235,8 @@ namespace Api.Core.Services
                 }
 
                 // If we're not in a transaction, retry the query if it's a deadlock.
-                if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number))
+                var errorCode = (MySqlErrorCode)mySqlException.Number;
+                if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(errorCode))
                 {
                     Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
                     return await GetAsync(query, retryCount + 1, cleanUp, useWritingConnectionIfAvailable);
@@ -317,7 +318,8 @@ namespace Api.Core.Services
                 }
 
                 // If we're not in a transaction, retry the query if it's a deadlock.
-                if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number))
+                var errorCode = (MySqlErrorCode)mySqlException.Number;
+                if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains( errorCode ))
                 {
                     Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
                     return await ExecuteAsync(query, retryCount + 1, useWritingConnectionIfAvailable, cleanUp);
@@ -443,7 +445,8 @@ namespace Api.Core.Services
                 }
 
                 // If we're not in a transaction, retry the query if it's a deadlock.
-                if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number))
+                var errorCode = (MySqlErrorCode)mySqlException.Number;
+                if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(errorCode))
                 {
                     Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
                     return await InsertRecordAsync(query, retryCount + 1, useWritingConnectionIfAvailable);


### PR DESCRIPTION
# Describe your changes

during testing i ran into compile issues, seems like checking for retry no longer is valid with the int value that returns, these need to be mysql error codes, i added a cast in 3 places for this, This checks for retries so cast should be save, if no valid value is inserted the check will still not have those values to compare to anyway.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?
tested on wiserdemo

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests
NA

# Link to Asana ticket
Not for this