### PR TITLE
Update InsertInitialData.sql with queries for setting the parent_item…

### DIFF
--- a/Api/Core/Queries/WiserInstallation/InsertInitialData.sql
+++ b/Api/Core/Queries/WiserInstallation/InsertInitialData.sql
@@ -314,6 +314,8 @@ INSERT INTO `wiser_link` (`type`, `destination_entity_type`, `connected_entity_t
 INSERT INTO `wiser_link` (`type`, `destination_entity_type`, `connected_entity_type`, `name`, `show_in_tree_view`, `show_in_data_selector`, `relationship`, `duplication`, `use_item_parent_id`) VALUES (1, 'map', 'vatrule', 'vatrule', 1, 0, 'one-to-one', 'none', 1);
 INSERT INTO `wiser_link` (`type`, `destination_entity_type`, `connected_entity_type`, `name`, `show_in_tree_view`, `show_in_data_selector`, `relationship`, `duplication`, `use_item_parent_id`) VALUES (1, 'map', 'country', 'country', 1, 0, 'one-to-one', 'none', 1);
 INSERT INTO `wiser_link` (`type`, `destination_entity_type`, `connected_entity_type`, `name`, `show_in_tree_view`, `show_in_data_selector`, `relationship`, `duplication`, `use_item_parent_id`) VALUES (1, 'map', 'dataselector-template', 'dataselector-template', 1, 0, 'one-to-one', 'none', 1);
+INSERT INTO `wiser_link` (`type`, `destination_entity_type`, `connected_entity_type`, `name`, `show_in_tree_view`, `show_in_data_selector`, `relationship`, `duplication`, `use_item_parent_id`) VALUES (1, 'Directory', 'webpagina', 'WebPageUnderDirectory', 1, 0, 'one-to-many', 'copy-item', 1);
+INSERT INTO `wiser_link` (`type`, `destination_entity_type`, `connected_entity_type`, `name`, `show_in_tree_view`, `show_in_data_selector`, `relationship`, `duplication`, `use_item_parent_id`) VALUES (1, 'Directory', 'Directory', 'DirectoryUnderDirectory', 1, 1, 'one-to-many', 'copy-item', 1);
 
 -- ----------------------------
 -- Records of wiser_data_selector


### PR DESCRIPTION
# Describe your changes

Add 2 queries to InsertInitialData.sql for setting the parent_item_id when creating a webpage under a map. Created and tested it together with @GilianJuice.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I added the two wiser_itemlink records in a customer's environment. After that, I created a new webpage under a specific map and verified the database to ensure it received a parent_item_id. 

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

none

# Link to Asana ticket

https://app.asana.com/0/1207852342873635/1206998216789095
