### PR TITLE
Bugfix openiddict encryption key

### DIFF
--- a/Api/Startup.cs
+++ b/Api/Startup.cs
@@ -233,10 +233,11 @@ namespace Api
                         var encryptionCertificateName = Configuration.GetValue<string>("Api:EncryptionCredentialCertificate");
                         if (!String.IsNullOrWhiteSpace(encryptionCertificateName))
                         {
-                            options.AddEncryptionCertificate(GetCertificateByName(signingCertificateName));
+                            options.AddEncryptionCertificate(GetCertificateByName(encryptionCertificateName));
                         }
                         else
                         {
+                            options.AddEncryptionCertificate(signingCertificate);
                             options.DisableAccessTokenEncryption();
                         }
                     }


### PR DESCRIPTION
# Describe your changes

Fixes 2 bugs that has to do with the encryption key for openiddict.

The first bug is that the signing key was used for encryption due to the wrong parameter being given to options.AddEncryptionCertificate.

The second is that the encryption is still needed even if AccessTokenEncryption is disabled. Because of this Wiser wouldn't work if the encryption key isn't given in the appsettings. This is supposed to be optional in Wiser. This is fixed by using the Signing Key as encryption key if none was supplied.

Using a separate encryption key is still recommended.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested using the same key as both signing and encryption key.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1201027711166952/1208952541276646/f
