### PR TITLE
Extend Wiser beheer interface to allow configuring api calls for acti…

### DIFF
--- a/Api/Modules/ApiConnections/Controllers/ApiConnectionsController.cs
+++ b/Api/Modules/ApiConnections/Controllers/ApiConnectionsController.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Net.Mime;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -27,6 +28,17 @@ public class ApiConnectionsController : Controller
     public ApiConnectionsController(IApiConnectionsService apiConnectionsService)
     {
         this.apiConnectionsService = apiConnectionsService;
+    }
+
+    /// <summary>
+    /// Gets the settings for all external API connections.
+    /// </summary>
+    /// <returns>A list of <see cref="ApiConnectionModel"/>s with the settings.</returns>
+    [HttpGet]
+    [ProducesResponseType(typeof(List<ApiConnectionModel>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetSettingsAsync()
+    {
+        return (await apiConnectionsService.GetSettingsAsync((ClaimsIdentity) User.Identity)).GetHttpResponseMessage();
     }
 
     /// <summary>

--- a/Api/Modules/ApiConnections/Interfaces/IApiConnectionsService.cs
+++ b/Api/Modules/ApiConnections/Interfaces/IApiConnectionsService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Api.Core.Services;
@@ -10,6 +11,13 @@ namespace Api.Modules.ApiConnections.Interfaces;
 /// </summary>
 public interface IApiConnectionsService
 {
+    /// <summary>
+    /// Gets the settings for all external API connections.
+    /// </summary>
+    /// <param name="identity">The authenticated user.</param>
+    /// <returns>A list of <see cref="ApiConnectionModel"/>s with the settings.</returns>
+    Task<ServiceResult<List<ApiConnectionModel>>> GetSettingsAsync(ClaimsIdentity identity);
+    
     /// <summary>
     /// Gets the settings for communicating with an external API.
     /// </summary>

--- a/Api/Modules/ApiConnections/Models/ApiConnectionModel.cs
+++ b/Api/Modules/ApiConnections/Models/ApiConnectionModel.cs
@@ -13,6 +13,11 @@ public class ApiConnectionModel
     public int Id { get; set; }
     
     /// <summary>
+    /// Gets or sets the name of the connection.
+    /// </summary>
+    public string Name { get; set; }
+    
+    /// <summary>
     /// Gets or sets the options for the external API.
     /// </summary>
     public JToken Options { get; set; }

--- a/FrontEnd/Modules/Admin/Scripts/Admin.js
+++ b/FrontEnd/Modules/Admin/Scripts/Admin.js
@@ -127,6 +127,7 @@ const moduleSettings = {
                 EXECUTEQUERYONCE: { text: "Voer query eenmalig uit", id: "executeQueryOnce" },
                 GENERATEFILE: { text: "Genereer bestand", id: "generateFile" },
                 REFRESHCURRENTITEM: { text: "Ververs het item", id: "refreshCurrentItem" },
+                APICALL: { text: "Voer een API call uit", id: "apiCall" },
                 ACTIONCONFIRMDIALOG: { text: "Bevestigingsvenster", id: "actionConfirmDialog" },
                 CUSTOM: { text: "Custom javascript", id: "custom" }
             });

--- a/FrontEnd/Modules/Admin/Views/Admin/Index.cshtml
+++ b/FrontEnd/Modules/Admin/Views/Admin/Index.cshtml
@@ -1288,6 +1288,9 @@
                                                                         <li data-visible="generateFile">
                                                                             Genereer bestand
                                                                         </li>
+                                                                        <li data-visible="apiCall">
+                                                                            API call
+                                                                        </li>
                                                                         <li data-visible="actionConfirmDialog">
                                                                             Bevestigingsvenster
                                                                         </li>
@@ -1411,6 +1414,22 @@
                                                                                 <span class="info" data-type="action-button-pdf-filename"><ins class="icon-info-full"></ins></span>
                                                                             </h4>
                                                                             <input type="text" id="pdfFilename" class="textField k-input" maxlength="255" autocomplete="off" />
+                                                                        </div>
+                                                                    </div>
+                                                                    <div>
+                                                                        <div class="item">
+                                                                            <h4>
+                                                                                <label>API connectie</label>
+                                                                                <span class="info" data-type="action-button-api-call-connection"><ins class="icon-info-full"></ins></span>
+                                                                            </h4>
+                                                                            <select id="actionButtonApiCallConnection">
+                                                                            </select>
+                                                                        </div>
+                                                                        <div class="item">
+                                                                            <label class="checkbox">
+                                                                                <input id="actionButtonApiCallIterative" type="checkbox" />
+                                                                                <span>API call iteratief uitvoeren</span>
+                                                                            </label>
                                                                         </div>
                                                                     </div>
                                                                     <div>


### PR DESCRIPTION
# Describe your changes

Extend Wiser beheer interface to allow configuring api calls for action buttons through the Wiser interface instead of only using the database.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by checking if the settings are saved in the correct format and loaded again in a test environment.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1201027711166952/1209138189328469
