### PR TITLE
solve issue were admin context menu would not open for admins

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -639,7 +639,7 @@ export class Fields {
      * @param {any} event
      */
     onFieldLabelContextMenu(event) {
-        if (!this.base.settings.adminlogin) {
+        if (!this.base.settings.adminAccountLoggedIn) {
             return;
         }
 


### PR DESCRIPTION
# Describe your changes

in a previous bugfix some variable changes were made for the admin settings, however 1 line was accidentlity replaced while it should have been kept. this commit reverses that change, making the admin context work again

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?
locally with wiserdemo

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests
none

# Link to Asana ticket

no just related to Gilians pride

