### PR TITLE
Focus content builder window

### DIFF
--- a/FrontEnd/Modules/Base/Scripts/Utils.js
+++ b/FrontEnd/Modules/Base/Scripts/Utils.js
@@ -1317,6 +1317,11 @@ export class Wiser {
                         event.sender.title("Template invoegen");
                         break;
                 }
+            },
+            close: () => {
+                if (fileManagerWindowSender.contentbuilder && window.contentBuilderIframeWindow && window.contentBuilderIframeWindow.toFront) {
+                    window.contentBuilderIframeWindow.toFront();
+                }
             }
         }).data("kendoWindow");
 

--- a/FrontEnd/Modules/Dashboard/Views/Dashboard/Index.cshtml
+++ b/FrontEnd/Modules/Dashboard/Views/Dashboard/Index.cshtml
@@ -142,6 +142,12 @@
                         <a class="k-button k-button-flat-base k-button-flat k-button-md k-rounded-md k-icon-button k-close-button"><span class="k-button-icon k-icon k-i-close"></span></a>
                         <div class="tile-content" data-tile="updateLog">
                             <div class="log-item">
+                                <h4>Versie 3.6.2503.1 - 17 maart 2025</h4>
+                                <ul>
+                                    <li><ins class="icon-check"></ins><span>Content builder: Het content builder scherm wordt weer naar voren gebracht na het sluiten van het "Afbeelding invoegen" scherm.</span></li>
+                                </ul>
+                            </div>
+                            <div class="log-item">
                                 <h4>Versie 3.6.2502.3 - 17 februari 2025</h4>
                                 <ul>
                                     <li><ins class="icon-check"></ins><span>Actie knoppen: Mogelijkheid om het resultaat van een API-request te tonen in een popup.</span></li>

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -3192,17 +3192,19 @@ export class Fields {
         }
         iframe.attr("src", `/Modules/${moduleName}?wiserItemId=${encodeURIComponent(itemId)}&propertyName=${encodeURIComponent(propertyName)}&languageCode=${encodeURIComponent(languageCode || "")}&userId=${encodeURIComponent(this.base.settings.userId)}`);
 
-        htmlWindow.kendoWindow({
-            width: "100%",
-            height: "100%",
-            title: "Content builder",
-            close: (closeEvent) => {
-                closeEvent.sender.destroy();
-                htmlWindow.remove();
-            }
-        });
-
-        const kendoWindow = htmlWindow.data("kendoWindow").maximize().open();
+        if (!window.contentBuilderIframeWindow || !(window.contentBuilderIframeWindow instanceof kendo.ui.Window)) {
+            window.contentBuilderIframeWindow = htmlWindow.kendoWindow({
+                width: "100%",
+                height: "100%",
+                title: "Content builder",
+                close: (closeEvent) => {
+                    closeEvent.sender.destroy();
+                    htmlWindow.remove();
+                    delete window.contentBuilderIframeWindow;
+                }
+            }).getKendoWindow();
+        }
+        window.contentBuilderIframeWindow.maximize().open();
 
         htmlWindow.find(".k-primary, .k-button-solid-primary").kendoButton({
             click: () => {
@@ -3214,14 +3216,14 @@ export class Fields {
                 const container = editor.element.closest(".entity-container");
                 container.find(".saveBottomPopup, .saveButton").trigger("click");
 
-                kendoWindow.close();
+                window.contentBuilderIframeWindow.close();
             },
             icon: "save"
         });
 
         htmlWindow.find(".k-secondary").kendoButton({
             click: () => {
-                kendoWindow.close();
+                window.contentBuilderIframeWindow.close();
             },
             icon: "cancel"
         });
@@ -3231,7 +3233,6 @@ export class Fields {
      * Event that gets called when the user executes the custom action for maximizing an HTML editor.
      * @param {any} event The event from the execute action.
      * @param {any} editor The HTML editor where the action is executed in.
-     * @param {any} itemId The ID of the current item.
      */
     async onHtmlEditorFullScreenExec(event, editor) {
         const htmlWindow = $("#maximizeEditorWindow").clone(true);


### PR DESCRIPTION
# Describe your changes

After closing the file manager window the content builder window would not be brought back into focus. This PR fixes that by checking if there's a content builder window active and tries to bring it back into focus.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Used a debug build of Wiser and checked if the content builder window would correctly be brought to the front after the file manager window closes (and thus bringing it back into focus).

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Release note update
- [x] This change is a "nice" thing to mention to our costumers in the change log, so I added it.

# Related pull requests

None.

# Link to Asana ticket

[Asana ticket](https://app.asana.com/0/1201027711166952/1207811525392664)