### PR TITLE
Changed when "check for conflicts" is valid

### DIFF
--- a/FrontEnd/Core/Scripts/shared/branches.service.js
+++ b/FrontEnd/Core/Scripts/shared/branches.service.js
@@ -124,7 +124,7 @@ export default class BranchesService extends BaseService {
                 entities: [],
                 settings: [],
                 linkTypes: [],
-                checkForConflicts: data.checkForConflicts,
+                checkForConflicts: data.mergeType === "direct" && data.checkForConflicts,
                 conflictSettings: data.conflicts.map(conflict => {
                     return {
                         id: conflict.id,


### PR DESCRIPTION
# Describe your changes

The option to check for conflicts when merging a branch is now only enabled when an actual merge is made and not when saving a template.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Used a dev build to check if saving a template no longer triggered the "check for conflicts" functionality.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable
- [ ] I added my change to the release notes of the dashboard module, if this is useful to know for our customers.

# Related pull requests

None.

# Link to Asana ticket

[Asana ticket](https://app.asana.com/0/1205090868730163/1209213868918559)