### PR TITLE
Fixed bug in `{tablePrefix}DetailDelete`

### DIFF
--- a/Api/Core/Queries/WiserInstallation/CreateDedicatedItemTablesTriggers.sql
+++ b/Api/Core/Queries/WiserInstallation/CreateDedicatedItemTablesTriggers.sql
@@ -202,7 +202,7 @@ DROP TRIGGER IF EXISTS `{tablePrefix}DetailDelete`;
 CREATE TRIGGER `{tablePrefix}DetailDelete` AFTER DELETE ON `{tablePrefix}wiser_itemdetail` FOR EACH ROW BEGIN
     IF IFNULL(@saveHistory, TRUE) = TRUE THEN
         INSERT INTO wiser_history (action, tablename, target_id, item_id, changed_by, field, oldvalue, newvalue, language_code, groupname)
-        VALUES ('UPDATE_ITEM', '{tablePrefix}wiser_itemdetail', NEW.id, OLD.item_id, IFNULL(@_username, USER()), OLD.`key`, CONCAT_WS('', OLD.`value`, OLD.`long_value`), '', OLD.language_code, OLD.groupname);
+        VALUES ('UPDATE_ITEM', '{tablePrefix}wiser_itemdetail', OLD.id, OLD.item_id, IFNULL(@_username, USER()), OLD.`key`, CONCAT_WS('', OLD.`value`, OLD.`long_value`), '', OLD.language_code, OLD.groupname);
     END IF;
 
     IF IFNULL(@performParentUpdate, FALSE) = TRUE THEN


### PR DESCRIPTION
# Describe your changes

The query doesn't work at the moment because NEW doesn't exist in that context. This fixes it.

## Type of change

Please check only ONE option.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Please describe how you tested your changes and how you confirmed this functionality is not a breaking change.

# Checklist before requesting a review
- [X] I have reviewed and tested my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [X] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable
- [ ] I added my change to the release notes of the dashboard module, if this is useful to know for our customers.

# Related pull requests



# Link to Asana ticket

