### PR TITLE
ensure that begin and end styled output also make use of replacements

### DIFF
--- a/Api/Modules/Queries/Services/StyledOutputService.cs
+++ b/Api/Modules/Queries/Services/StyledOutputService.cs
@@ -316,7 +316,8 @@ public class StyledOutputService : IStyledOutputService, IScopedService
 
             if (!String.IsNullOrEmpty(style.FormatBegin))
             {
-                combinedResult.Append(style.FormatBegin);
+                var formattedBegin = stringReplacementsService.DoReplacements(style.FormatBegin, result);
+                combinedResult.Append(formattedBegin);
             }
 
             foreach (var parsedObject in result.Children<JObject>())
@@ -350,7 +351,8 @@ public class StyledOutputService : IStyledOutputService, IScopedService
 
             if (!String.IsNullOrWhiteSpace(style.FormatEnd))
             {
-                combinedResult.Append(style.FormatEnd);
+                var formattedEnd = stringReplacementsService.DoReplacements(style.FormatEnd, result);
+                combinedResult.Append(formattedEnd);
             }
         }
 


### PR DESCRIPTION
# Describe your changes

IT's a small change to make sure we also apply replacements on the begin and end texts in styled outputs

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

tested it on wiser demo

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable
- [ ] I added my change to the release notes of the dashboard module, if this is useful to know for our customers.

# Related pull requests

none
# Link to Asana ticket

none