### PR TITLE
Add WiserHostNames configuration to development settings

### DIFF
--- a/FrontEnd/appsettings.Development.json
+++ b/FrontEnd/appsettings.Development.json
@@ -5,6 +5,7 @@
   },
   "FrontEnd": {
     "ApiBaseUrl": "https://localhost:44349/",
-    "PluginsDirectory": "..\\Api\\Plugins"
+    "PluginsDirectory": "..\\Api\\Plugins",
+    "WiserHostNames": [ ".wiser.nl", ".wiser3.nl", ".localhost" ]
   }
 }


### PR DESCRIPTION
# Describe your changes

Makes wiser correctly response to localhost subdomains (*.localhost) which so these urls can be used to easily switch between wiser tenants without having to make edits into settings like the hosts file.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Switched to different tenants and logged in.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable
- [ ] I added my change to the release notes of the dashboard module, if this is useful to know for our customers.

# Related pull requests

N/A

# Link to Asana ticket

N/A