### PR TITLE
Fixed problem that creating items with a parentId, would not link them correctly in certain situations

### DIFF
--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -72,8 +72,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GeeksCoreLibrary" Version="5.3.2504.3" />
-    <PackageReference Include="GeeksCoreLibrary.Modules.GclConverters.EvoPdf" Version="5.3.2504.3" />
+    <PackageReference Include="GeeksCoreLibrary" Version="5.3.2505.1" />
+    <PackageReference Include="GeeksCoreLibrary.Modules.GclConverters.EvoPdf" Version="5.3.2505.1" />
     <PackageReference Include="Google.Cloud.Translation.V2" Version="3.4.0" />
     <PackageReference Include="GoogleAuthenticator" Version="3.2.0" />
     <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.27.3" />

--- a/Api/Modules/Items/Controllers/ItemsController.cs
+++ b/Api/Modules/Items/Controllers/ItemsController.cs
@@ -252,7 +252,7 @@ public class ItemsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> PostAsync(WiserItemModel item, [FromQuery]ulong? parentId = null, [FromQuery]int linkType = 1, [FromQuery] bool alsoCreateInMainBranch = false, [FromQuery] string parentEntityType = null)
     {
-        return (await itemsService.CreateAsync(item, (ClaimsIdentity)User.Identity, parentId ?? 0, linkType, alsoCreateInMainBranch)).GetHttpResponseMessage();
+        return (await itemsService.CreateAsync(item, (ClaimsIdentity)User.Identity, parentId ?? 0, linkType, alsoCreateInMainBranch, parentEntityType)).GetHttpResponseMessage();
     }
 
     /// <summary>

--- a/Api/Modules/Items/Controllers/ItemsController.cs
+++ b/Api/Modules/Items/Controllers/ItemsController.cs
@@ -224,16 +224,17 @@ public class ItemsController : ControllerBase
     /// <param name="item">The item to create.</param>
     /// <param name="parentId">Optional: The encrypted ID of the parent to create this item under.</param>
     /// <param name="linkType">Optional: The link type of the link to the parent.</param>
-    /// <param name="alsoCreateInMainBranch"></param>
+    /// <param name="alsoCreateInMainBranch">Optional: Whether to also create the item in the main branch. Default is <see langword="false"/>.</param>
+    /// <param name="parentEntityType">Optional: The entity type of the parent item. We need this to determine where and how to save the parent link.</param>
     /// <returns>A CreateItemResultModel with information about the newly created item.</returns>
     [HttpPost]
     [ProducesResponseType(typeof(CreateItemResultModel), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    public async Task<IActionResult> PostAsync(WiserItemModel item, [FromQuery]string parentId = null, [FromQuery]int linkType = 1, [FromQuery] bool alsoCreateInMainBranch = false)
+    public async Task<IActionResult> PostAsync(WiserItemModel item, [FromQuery]string parentId = null, [FromQuery]int linkType = 1, [FromQuery] bool alsoCreateInMainBranch = false, [FromQuery] string parentEntityType = null)
     {
         var identity = (ClaimsIdentity)User.Identity;
         var itemId = await wiserTenantsService.DecryptValue<ulong>(parentId, identity);
-        return (await itemsService.CreateAsync(item, identity, itemId, linkType, alsoCreateInMainBranch)).GetHttpResponseMessage();
+        return (await itemsService.CreateAsync(item, identity, itemId, linkType, alsoCreateInMainBranch, parentEntityType)).GetHttpResponseMessage();
     }
 
     /// <summary>
@@ -242,13 +243,14 @@ public class ItemsController : ControllerBase
     /// <param name="item">The item to create.</param>
     /// <param name="parentId">Optional: The ID of the parent to create this item under.</param>
     /// <param name="linkType">Optional: The link type of the link to the parent.</param>
-    /// <param name="alsoCreateInMainBranch"></param>
+    /// <param name="alsoCreateInMainBranch">Optional: Whether to also create the item in the main branch. Default is <see langword="false"/>.</param>
+    /// <param name="parentEntityType">Optional: The entity type of the parent item. We need this to determine where and how to save the parent link.</param>
     /// <returns>A CreateItemResultModel with information about the newly created item.</returns>
     [HttpPost]
     [Route("~/api/v4/[controller]")]
     [ProducesResponseType(typeof(CreateItemResultModel), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    public async Task<IActionResult> PostAsync(WiserItemModel item, [FromQuery]ulong? parentId = null, [FromQuery]int linkType = 1, [FromQuery] bool alsoCreateInMainBranch = false)
+    public async Task<IActionResult> PostAsync(WiserItemModel item, [FromQuery]ulong? parentId = null, [FromQuery]int linkType = 1, [FromQuery] bool alsoCreateInMainBranch = false, [FromQuery] string parentEntityType = null)
     {
         return (await itemsService.CreateAsync(item, (ClaimsIdentity)User.Identity, parentId ?? 0, linkType, alsoCreateInMainBranch)).GetHttpResponseMessage();
     }
@@ -753,7 +755,7 @@ public class ItemsController : ControllerBase
             destinationIds.Add(decryptedDestinationId);
         }
 
-        return (await itemsService.AddMultipleLinksAsync(identity, sourceIds, destinationIds, data.LinkType, data.SourceEntityType)).GetHttpResponseMessage();
+        return (await itemsService.AddMultipleLinksAsync(identity, sourceIds, destinationIds, data.LinkType, data.SourceEntityType, data.DestinationEntityType)).GetHttpResponseMessage();
     }
 
     /// <summary>
@@ -765,7 +767,7 @@ public class ItemsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> AddMultipleLinksAsync([FromBody]AddOrRemoveLinksRequestModel data)
     {
-        return (await itemsService.AddMultipleLinksAsync((ClaimsIdentity)User.Identity, data.SourceIds, data.DestinationIds, data.LinkType, data.SourceEntityType)).GetHttpResponseMessage();
+        return (await itemsService.AddMultipleLinksAsync((ClaimsIdentity)User.Identity, data.SourceIds, data.DestinationIds, data.LinkType, data.SourceEntityType, data.DestinationEntityType)).GetHttpResponseMessage();
     }
 
     /// <summary>
@@ -793,7 +795,7 @@ public class ItemsController : ControllerBase
             destinationIds.Add(decryptedDestinationId);
         }
 
-        return (await itemsService.RemoveMultipleLinksAsync((ClaimsIdentity)User.Identity, sourceIds, destinationIds, data.LinkType, data.SourceEntityType)).GetHttpResponseMessage();
+        return (await itemsService.RemoveMultipleLinksAsync((ClaimsIdentity)User.Identity, sourceIds, destinationIds, data.LinkType, data.SourceEntityType, data.DestinationEntityType)).GetHttpResponseMessage();
     }
 
     /// <summary>
@@ -805,7 +807,7 @@ public class ItemsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> RemoveMultipleLinksAsync([FromBody]AddOrRemoveLinksRequestModel data)
     {
-        return (await itemsService.RemoveMultipleLinksAsync((ClaimsIdentity)User.Identity, data.SourceIds, data.DestinationIds, data.LinkType, data.SourceEntityType)).GetHttpResponseMessage();
+        return (await itemsService.RemoveMultipleLinksAsync((ClaimsIdentity)User.Identity, data.SourceIds, data.DestinationIds, data.LinkType, data.SourceEntityType, data.DestinationEntityType)).GetHttpResponseMessage();
     }
 
     /// <summary>

--- a/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
+++ b/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
@@ -24,13 +24,13 @@ if (options.fieldGroupName) {
 }
 
 if (customQueryGrid) {
-    Wiser.api({ 
-        url: `${window.dynamicItems.settings.wiserApiRoot}items/${encodeURIComponent("{itemIdEncrypted}")}/grids/{propertyId}${linkTypeParameter}` 
+    Wiser.api({
+        url: `${window.dynamicItems.settings.wiserApiRoot}items/${encodeURIComponent("{itemIdEncrypted}")}/grids/{propertyId}${linkTypeParameter}`
     }).then(function(customQueryResults) {
         if (customQueryResults.extraJavascript) {
             jQuery.globalEval(customQueryResults.extraJavascript);
         }
-        
+
         if (!hideCheckboxColumn) {
             customQueryResults.columns.splice(0, 0, {
                 selectable: true,
@@ -44,14 +44,14 @@ if (customQueryGrid) {
                 options.disableOpeningOfItems = !(customQueryResults.schemaModel.fields.encryptedId || customQueryResults.schemaModel.fields.encrypted_id || customQueryResults.schemaModel.fields.encryptedid || customQueryResults.schemaModel.fields.idencrypted);
             }
         }
-        
+
         if (!options.hideCommandColumn) {
             let commandColumnWidth = 0;
             let commands = [];
-            
+
             if (!options.disableOpeningOfItems) {
                 commandColumnWidth += 60;
-                
+
                 commands.push({
                     name: "openDetails",
                     iconClass: "k-icon k-i-hyperlink-open",
@@ -59,7 +59,7 @@ if (customQueryGrid) {
                     title: "Item openen",
                     click: function(event) { window.dynamicItems.grids.onShowDetailsClick(event, kendoComponent, options, false); }
                 });
-                
+
                 if (options.allowOpeningOfItemsInNewTab) {
                     commandColumnWidth += 60;
 
@@ -75,7 +75,7 @@ if (customQueryGrid) {
 
             if (!readonly && options.deletionOfItems && options.deletionOfItems.toLowerCase() !== "off") {
                 commandColumnWidth += 60;
-                
+
                 commands.push({
                     name: "remove",
                     text: "",
@@ -84,7 +84,7 @@ if (customQueryGrid) {
                 });
             } else if (!readonly && customQueryGrid && options.hasCustomDeleteQuery) {
                 commandColumnWidth += 120;
-                
+
                 commands.push("destroy");
             }
 
@@ -96,7 +96,7 @@ if (customQueryGrid) {
                 });
             }
         }
-        
+
         generateGrid(customQueryResults.data, customQueryResults.schemaModel, customQueryResults.columns);
     });
 } else {
@@ -107,16 +107,16 @@ if (customQueryGrid) {
                 columns: options.columns
             };
         }
-        
+
         if (gridSettings.extraJavascript) {
             jQuery.globalEval(gridSettings.extraJavascript);
         }
-        
+
         // Add most columns here.
         if (gridSettings.columns && gridSettings.columns.length) {
             for (var i = 0; i < gridSettings.columns.length; i++) {
                 var column = gridSettings.columns[i];
-                
+
                 switch ((column.field || "").toLowerCase()) {
                     case "":
                         column.hidden = hideCheckboxColumn;
@@ -165,12 +165,12 @@ if (customQueryGrid) {
                 options.disableOpeningOfItems = !(gridSettings.schemaModel.fields.encryptedId || gridSettings.schemaModel.fields.encrypted_id || gridSettings.schemaModel.fields.encryptedid || gridSettings.schemaModel.fields.idencrypted);
             }
         }
-        
+
         // Add command columns separately, because of the click event that we can't do properly server-side.
         if (!options.hideCommandColumn) {
             let commandColumnWidth = 0;
             let commands = [];
-            
+
             if (!options.disableOpeningOfItems && !options.fieldGroupName) {
                 commandColumnWidth += 60;
                 commands.push({
@@ -191,10 +191,10 @@ if (customQueryGrid) {
                     });
                 }
             }
-            
+
             if (!readonly && options.deletionOfItems && options.deletionOfItems.toLowerCase() !== "off" && !options.fieldGroupName) {
                 commandColumnWidth += 60;
-                
+
                 commands.push({
                     name: "remove",
                     text: "",
@@ -202,7 +202,7 @@ if (customQueryGrid) {
                     click: function(event) { window.dynamicItems.grids.onDeleteItemClick(event, this, options.deletionOfItems, options); }
                 });
             }
-            
+
             if (gridSettings.columns && commands.length > 0) {
                 gridSettings.columns.push({
                     title: "&nbsp;",
@@ -211,10 +211,10 @@ if (customQueryGrid) {
                 });
             }
         }
-        
+
         generateGrid(gridSettings.data, gridSettings.schemaModel, gridSettings.columns);
     }
-    
+
     if (usingDataSelector) {
         Wiser.api({
             url: `${window.dynamicItems.settings.getItemsUrl}?trace=false&encryptedDataSelectorId=${encodeURIComponent(options.dataSelectorId)}&itemId=${encodeURIComponent("{itemIdEncrypted}")}`,
@@ -227,7 +227,7 @@ if (customQueryGrid) {
             contentType: "application/json"
         }).then(done);
     }
-}    
+}
 async function generateGrid(data, model, columns) {
     var toolbar = [];
     if (!options.toolbar || !options.toolbar.hideExportButton) {
@@ -274,7 +274,7 @@ async function generateGrid(data, model, columns) {
             : {
                 name: "add",
                 text: "Nieuw",
-                template: "<a class='k-button k-button-icontext' href='\\#' onclick='return window.dynamicItems.grids.onNewSubEntityClick(\"{itemIdEncrypted}\", \"" + options.entityType + "\", \"\\#overviewGrid{propertyIdWithSuffix}\", " + !options.hideTitleColumn + ", \"" + (options.linkTypeNumber || "") + "\")'><span class='k-icon k-i-file-add'></span>" + window.dynamicItems.getEntityTypeFriendlyName(options.entityType) + " toevoegen</a>"
+                template: `<a class='k-button k-button-icontext' href='\\#' onclick='return window.dynamicItems.grids.onNewSubEntityClick("{itemIdEncrypted}", "${options.entityType}", "\\#overviewGrid{propertyIdWithSuffix}", ${!options.hideTitleColumn}, ${options.linkTypeNumber || 0}, "{entityType}")'><span class='k-icon k-i-file-add'></span>${window.dynamicItems.getEntityTypeFriendlyName(options.entityType)} toevoegen</a>`
             });
     }
 
@@ -577,9 +577,9 @@ async function generateGrid(data, model, columns) {
                         if (options.fieldGroupName) {
                             let itemModel = {
                                 details: [],
-                                entityType: "{entityType}" 
+                                entityType: "{entityType}"
                             };
-                            
+
                             const encryptedId = "{itemIdEncrypted}";
                             transportOptions.data.groupName = options.fieldGroupName;
                             // If we have a predefined language code, then always force that language code, so that the user doesn't have to enter it manually.

--- a/Api/Modules/Items/Interfaces/IItemsService.cs
+++ b/Api/Modules/Items/Interfaces/IItemsService.cs
@@ -61,8 +61,9 @@ public interface IItemsService
     /// <param name="parentId">Optional: The encrypted ID of the parent to create this item under.</param>
     /// <param name="linkType">Optional: The link type of the link to the parent.</param>
     /// <param name="alsoCreateInMainBranch">Optional: Whether to also create the item in the main branch. Default is <see langword="false"/>.</param>
+    /// <param name="parentEntityType">Optional: The entity type of the parent item. We need this to determine where and how to save the parent link.</param>
     /// <returns>A CreateItemResultModel with information about the newly created item.</returns>
-    Task<ServiceResult<CreateItemResultModel>> CreateAsync(WiserItemModel item, ClaimsIdentity identity, ulong? parentId = null, int linkType = 1, bool alsoCreateInMainBranch = false);
+    Task<ServiceResult<CreateItemResultModel>> CreateAsync(WiserItemModel item, ClaimsIdentity identity, ulong? parentId = null, int linkType = 1, bool alsoCreateInMainBranch = false, string parentEntityType = null);
 
     /// <summary>
     /// Updates an item.
@@ -244,8 +245,9 @@ public interface IItemsService
     /// <param name="sourceIds">The IDs of the items that are being linked.</param>
     /// <param name="destinationIds">The IDs of the destination items.</param>
     /// <param name="linkType">The link type to use for all of the links.</param>
-    /// <param name="sourceEntityType">Optional: The entity type of the items that are being linked. This is needed when the item is saved in a different table than wiser_item. We can only look up the name of that table if we know the entity type beforehand.</param>
-    Task<ServiceResult<bool>> AddMultipleLinksAsync(ClaimsIdentity identity, List<ulong> sourceIds, List<ulong> destinationIds, int linkType, string sourceEntityType = null);
+    /// <param name="sourceEntityType">The entity type of the items that are being linked. This is needed to be able to determine where and how to save the links.</param>
+    /// <param name="destinationEntityType">The entity type of the items that are being linked too. This is needed to be able to determine where and how to save the links.</param>
+    Task<ServiceResult<bool>> AddMultipleLinksAsync(ClaimsIdentity identity, List<ulong> sourceIds, List<ulong> destinationIds, int linkType, string sourceEntityType, string destinationEntityType);
 
     /// <summary>
     /// Removed one or more links between items.
@@ -254,8 +256,9 @@ public interface IItemsService
     /// <param name="sourceIds">The IDs of the source items of the links to remove.</param>
     /// <param name="destinationIds">The IDs of the destination items.</param>
     /// <param name="linkType">The link type to use for all of the links.</param>
-    /// <param name="sourceEntityType">Optional: The entity type of the source items. This is needed when the item is saved in a different table than wiser_item. We can only look up the name of that table if we know the entity type beforehand.</param>
-    Task<ServiceResult<bool>> RemoveMultipleLinksAsync(ClaimsIdentity identity, List<ulong> sourceIds, List<ulong> destinationIds, int linkType, string sourceEntityType = null);
+    /// <param name="sourceEntityType">The entity type of the items that are being linked. This is needed to be able to determine where and how to save the links.</param>
+    /// <param name="destinationEntityType">The entity type of the items that are being linked too. This is needed to be able to determine where and how to save the links.</param>
+    Task<ServiceResult<bool>> RemoveMultipleLinksAsync(ClaimsIdentity identity, List<ulong> sourceIds, List<ulong> destinationIds, int linkType, string sourceEntityType, string destinationEntityType);
 
     /// <summary>
     /// Translate all fields of an item into one or more other languages, using the Google Translation API.

--- a/Api/Modules/Items/Models/AddOrRemoveLinksRequestModel.cs
+++ b/Api/Modules/Items/Models/AddOrRemoveLinksRequestModel.cs
@@ -36,4 +36,9 @@ public class AddOrRemoveLinksRequestModel
     /// Gets or sets the entity type of the source item(s).
     /// </summary>
     public string SourceEntityType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the entity type of the destination item(s).
+    /// </summary>
+    public string DestinationEntityType { get; set; }
 }

--- a/FrontEnd/Core/Models/BaseViewModel.cs
+++ b/FrontEnd/Core/Models/BaseViewModel.cs
@@ -21,6 +21,8 @@ public class BaseViewModel
 
     public string ApiRoot { get; set; }
 
+    public string ApiRootV4 { get; set; }
+
     public string CurrentDomain { get; set; }
 
     public string IsWiserFrontEndLogin { get; set; }

--- a/FrontEnd/Core/Services/BaseService.cs
+++ b/FrontEnd/Core/Services/BaseService.cs
@@ -13,8 +13,7 @@ using Microsoft.Extensions.Options;
 
 namespace FrontEnd.Core.Services;
 
-public class BaseService(IHttpContextAccessor httpContextAccessor, IWebHostEnvironment webHostEnvironment, IOptions<FrontEndSettings> frontEndSettings, IOptions<GclSettings> gclSettings)
-    : IBaseService
+public class BaseService(IHttpContextAccessor httpContextAccessor, IWebHostEnvironment webHostEnvironment, IOptions<FrontEndSettings> frontEndSettings, IOptions<GclSettings> gclSettings) : IBaseService
 {
     public const int Wiser1DebuggingPortNumber = 54405;
 
@@ -69,18 +68,13 @@ public class BaseService(IHttpContextAccessor httpContextAccessor, IWebHostEnvir
             return $"http://{subDomain}:{Wiser1DebuggingPortNumber}/";
         }
 
-        if (requestUrl.Host.Contains("juicedev.nl", StringComparison.OrdinalIgnoreCase))
-        {
-            return $"http://{subDomain}.wiser.nl.juicedev.nl/";
-        }
-
         return $"https://{subDomain}.wiser.nl/";
     }
 
     /// <inheritdoc />
     public T CreateBaseViewModel<T>() where T : BaseViewModel
     {
-        var viewModel = (T)Activator.CreateInstance(typeof(T));
+        var viewModel = Activator.CreateInstance<T>();
         viewModel!.Settings = frontEndSettings;
         viewModel.WiserVersion = Assembly.GetEntryAssembly()?.GetName().Version;
         viewModel.SubDomain = GetSubDomain();
@@ -88,12 +82,13 @@ public class BaseService(IHttpContextAccessor httpContextAccessor, IWebHostEnvir
         viewModel.Wiser1BaseUrl = GetWiser1Url();
         viewModel.ApiAuthenticationUrl = $"{frontEndSettings.ApiBaseUrl}connect/token";
         viewModel.ApiRoot = $"{frontEndSettings.ApiBaseUrl}api/v3/";
+        viewModel.ApiRootV4 = $"{frontEndSettings.ApiBaseUrl}api/v4/";
         viewModel.IsWiserFrontEndLogin = "true".EncryptWithAesWithSalt(gclSettings.DefaultEncryptionKey, true, true);
 
         if (httpContextAccessor.HttpContext != null)
         {
             viewModel.CurrentDomain = httpContextAccessor.HttpContext.Request.Host.Value;
-            viewModel.CurrentDomain = viewModel.CurrentDomain.Replace($"{viewModel.SubDomain}.", "");
+            viewModel.CurrentDomain = viewModel.CurrentDomain?.Replace($"{viewModel.SubDomain}.", "");
         }
 
         var partnerStylesDirectory = new DirectoryInfo(Path.Combine(webHostEnvironment.ContentRootPath, "Core/Css/partner"));

--- a/FrontEnd/FrontEnd.csproj
+++ b/FrontEnd/FrontEnd.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GeeksCoreLibrary" Version="5.3.2504.3" />
+    <PackageReference Include="GeeksCoreLibrary" Version="5.3.2505.1" />
     <PackageReference Include="GoogleAuthenticator" Version="3.2.0" />
   </ItemGroup>
 

--- a/FrontEnd/Modules/Base/Scripts/Utils.js
+++ b/FrontEnd/Modules/Base/Scripts/Utils.js
@@ -1061,10 +1061,11 @@ export class Wiser {
      * @param {any} data Optional: The data to save with the new item.
      * @param {boolean} skipUpdate Optional: By default the updateItem function will be called after creating the item, to save the data of the item. Set this parameter to true if you want to skip that step (if you have no other data to save).
      * @param {number} moduleId Optional: The id of the module in which the item should be created.
+     * @param {boolean} alsoCreateInMainBranch Optional: Whether or not to create the item in the main branch as well to match IDs for merging later.
+     * @param {string} parentEntityType Optional: The entity type of the parent item. We need this to determine where and how to save the parent link.
      * @returns {Object<string, any>} An object with the properties 'itemId', 'icon' and 'workflowResult'.
-     * @param {bool} alsoCreateInMainBranch Optional: Whether or not to create the item in the main branch as well to match IDs for merging later.
      */
-    static async createItem(moduleSettings, entityType, parentId, name, linkTypeNumber, data = [], skipUpdate = false, moduleId = null, alsoCreateInMainBranch = false) {
+    static async createItem(moduleSettings, entityType, parentId, name, linkTypeNumber, data = [], skipUpdate = false, moduleId = 0, alsoCreateInMainBranch = false, parentEntityType = "") {
         try {
             const newItem = {
                 entityType: entityType,
@@ -1075,7 +1076,7 @@ export class Wiser {
             const parentIdUrlPart = parentId ? `&parentId=${encodeURIComponent(parentId)}` : "";
             const alsoCreateInMainBranchPart = alsoCreateInMainBranch ? "&alsoCreateInMainBranch=true" : ""; // Only add parameter if it has been set.
             const createItemResult = await Wiser.api({
-                url: `${moduleSettings.wiserApiRoot}items?linkType=${linkTypeNumber || 0}${parentIdUrlPart}&isNewItem=true${alsoCreateInMainBranchPart}`,
+                url: `${moduleSettings.wiserApiRoot}items?linkType=${linkTypeNumber || 0}${parentIdUrlPart}&isNewItem=true${alsoCreateInMainBranchPart}&parentEntityType=${parentEntityType}`,
                 method: "POST",
                 contentType: "application/json",
                 dataType: "JSON",

--- a/FrontEnd/Modules/DynamicItems/Controllers/DynamicItemsController.cs
+++ b/FrontEnd/Modules/DynamicItems/Controllers/DynamicItemsController.cs
@@ -20,6 +20,7 @@ public class DynamicItemsController(IBaseService baseService) : Controller
         viewModel.Wiser1BaseUrl = defaultModel.Wiser1BaseUrl;
         viewModel.ApiAuthenticationUrl = defaultModel.ApiAuthenticationUrl;
         viewModel.ApiRoot = defaultModel.ApiRoot;
+        viewModel.ApiRootV4 = defaultModel.ApiRootV4;
         viewModel.LoadPartnerStyle = defaultModel.LoadPartnerStyle;
 
         if (!String.IsNullOrWhiteSpace(viewModel.SaveButtonText))

--- a/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
@@ -180,6 +180,9 @@ const moduleSettings = {
             if (!this.settings.wiserApiRoot.endsWith("/")) {
                 this.settings.wiserApiRoot += "/";
             }
+            if (!this.settings.wiserApiRootV4.endsWith("/")) {
+                this.settings.wiserApiRootV4 += "/";
+            }
 
             // Get user data from API.
             const userData = await Wiser.getLoggedInUserData(this.settings.wiserApiRoot);
@@ -2099,12 +2102,14 @@ const moduleSettings = {
          * @param {string} name Optional: The name of the new item.
          * @param {number} linkTypeNumber Optional: The type number of the link between the new item and it's parent.
          * @param {any} data Optional: The data to save with the new item.
-         * @returns {Object<string, any>} An object with the properties 'itemId', 'icon' and 'workflowResult'.
+         * @param {boolean} skipUpdate Optional: By default the updateItem function will be called after creating the item, to save the data of the item. Set this parameter to true if you want to skip that step (if you have no other data to save).
          * @param {number} moduleId Optional: The id of the module in which the item should be created.
-         * @param {bool} alsoCreateInMainBranch Optional: Whether or not to create the item in the main branch as well to match IDs for merging later.
+         * @param {boolean} alsoCreateInMainBranch Optional: Whether or not to create the item in the main branch as well to match IDs for merging later.
+         * @param {string} parentEntityType Optional: The entity type of the parent item. We need this to determine where and how to save the parent link.
+         * @returns {Object<string, any>} An object with the properties 'itemId', 'icon' and 'workflowResult'.
          */
-        async createItem(entityType, parentId, name, linkTypeNumber, data = [], skipUpdate = false, moduleId = null, alsoCreateInMainBranch = false) {
-            return Wiser.createItem(this.settings, entityType, parentId, name, linkTypeNumber, data, skipUpdate, moduleId, alsoCreateInMainBranch);
+        async createItem(entityType, parentId, name, linkTypeNumber, data = [], skipUpdate = false, moduleId = 0, alsoCreateInMainBranch = false, parentEntityType = null) {
+            return Wiser.createItem(this.settings, entityType, parentId, name, linkTypeNumber, data, skipUpdate, moduleId, alsoCreateInMainBranch, parentEntityType);
         }
 
         /**

--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -1100,11 +1100,11 @@ export class Grids {
             if (customAction.doesDelete && !this.base.settings.permissions.canDelete) {
                 continue;
             }
-            
+
             const conditionAttribute = customAction.condition
                 ? `data-condition=${customAction.condition}`
                 : '';
-            
+
             const selector = gridSelector.replace(/#/g, "\\#");
 
             if (customAction.groupName) {
@@ -1118,7 +1118,7 @@ export class Grids {
 
                     groups.push(group);
                 }
-                
+
                 group.actions.push(`<a class='k-button k-button-icontext ${className}' href='\\#' ${conditionAttribute} onclick='return window.dynamicItems.fields.onSubEntitiesGridToolbarActionClick("${selector}", "${encryptedItemId}", "${propertyId}", ${JSON.stringify(customAction)}, event, "${entityType}")' style='${(kendo.htmlEncode(customAction.style || ""))}'><span>${customAction.text}</span></a>`);
             } else {
                 actionsWithoutGroups.push({
@@ -1329,8 +1329,9 @@ export class Grids {
      * @param {string} senderGridSelector The CSS selector to find the main element for the sub-entities-grid.
      * @param {boolean} showTitleField Whether or not to show the field where the user can edit the title/name of the new item.
      * @param {number} linkTypeNumber The link type number.
+     * @param {string} parentEntityType Optional: The entity type of the parent item. We need this to determine where and how to save the parent link.
      */
-    async onNewSubEntityClick(parentId, entityType, senderGridSelector, showTitleField, linkTypeNumber) {
+    async onNewSubEntityClick(parentId, entityType, senderGridSelector, showTitleField, linkTypeNumber, parentEntityType = null) {
         linkTypeNumber = linkTypeNumber || "";
 
         const senderGrid = $(senderGridSelector).data("kendoGrid");
@@ -1340,9 +1341,9 @@ export class Grids {
 
         try {
             // Create the new item.
-            const createItemResult = await this.base.createItem(entityType, parentId, "", linkTypeNumber);
+            const createItemResult = await this.base.createItem(entityType, parentId, "", linkTypeNumber, null, false, 0, false, parentEntityType);
             if (createItemResult) {
-                await this.base.windows.loadItemInWindow(true, createItemResult.itemIdPlain, createItemResult.itemId, entityType, null, showTitleField, senderGrid, { hideTitleColumn: !showTitleField }, createItemResult.linkId, `Nieuw(e) ${this.base.getEntityTypeFriendlyName(entityType)} aanmaken`);
+                await this.base.windows.loadItemInWindow(true, createItemResult.itemIdPlain, createItemResult.itemId, entityType, "", showTitleField, senderGrid, { hideTitleColumn: !showTitleField }, createItemResult.linkId, `Nieuw(e) ${this.base.getEntityTypeFriendlyName(entityType)} aanmaken`);
             }
         } catch (exception) {
             console.error(exception);
@@ -1588,10 +1589,10 @@ export class Grids {
         conditionalButtons.each(async function () {
             const button = $(this);
             const condition = button.data('condition');
-            
+
             // Do not hide buttons by default.
             let shouldHide = false;
-            
+
             // Conditional check.
             if(condition) {
                 // Gather field data for each selected row in the grid.
@@ -1612,11 +1613,11 @@ export class Grids {
                     return func(...parameterValues);
                 });
             }
-            
+
             // Show or hide the action button based on the evaluated condition or default value.
             button.toggleClass('hidden', shouldHide || event.sender.select().length === 0);
         });
-        
+
         // Check whether to hide a button group when no buttons are visible in the group.
         for (let buttonGroup of event.sender.wrapper.find(".k-button-drop")) {
             const buttonGroupElement = $(buttonGroup);

--- a/FrontEnd/Modules/DynamicItems/Views/DynamicItems/Index.cshtml
+++ b/FrontEnd/Modules/DynamicItems/Views/DynamicItems/Index.cshtml
@@ -48,6 +48,7 @@
       data-iframe-mode="@Model.IframeMode.ToString().ToLowerInvariant()"
       data-wiser-api-authentication-url="@Model.ApiAuthenticationUrl"
       data-wiser-api-root="@Model.ApiRoot"
+      data-wiser-api-root-v4="@Model.ApiRootV4"
       data-is-test-environment="@Model.IsTestEnvironment.ToString().ToLowerInvariant()"
       data-read-only="@Model.ReadOnly.ToString().ToLowerInvariant()"
       data-hide-footer="@Model.HideFooter.ToString().ToLowerInvariant()"

--- a/Wiser.Tests/Wiser.Tests.csproj
+++ b/Wiser.Tests/Wiser.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GeeksCoreLibrary" Version="5.3.2504.3" />
+        <PackageReference Include="GeeksCoreLibrary" Version="5.3.2505.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />


### PR DESCRIPTION
# Describe your changes

If the source and destination items use different table prefixes, then it would not find the correct link settings and not use `parent_item_id`. This happened most often with link type `1`, because that one is used for multiple entities.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

By creating new items with a parent id and checking if correct links are created.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

https://github.com/happy-geeks/geeks-core-library/pull/851

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1205090868730163/task/1206957555415824
https://app.asana.com/1/5038780173035/project/1205090868730163/task/1207511625868431
