### PR TITLE
Allow permissions for items to be set to specific entity

### DIFF
--- a/Api/Modules/Grids/Services/GridsService.cs
+++ b/Api/Modules/Grids/Services/GridsService.cs
@@ -470,7 +470,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                        # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                           LEFT JOIN {{WiserTableNames.WiserUserRoles}} user_role ON user_role.user_id = ?userId
-                                          LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                          LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                        {filters}
                                        WHERE [if({title}!)]i.title {title_filter}[else]TRUE[endif] 
@@ -502,7 +502,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                     # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                     LEFT JOIN {{WiserTableNames.WiserUserRoles}} user_role ON user_role.user_id = ?userId
-                                    LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                    LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                     {filters}
                                     WHERE [if({title}!)]i.title {title_filter}[else]TRUE[endif] 
@@ -530,7 +530,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                         # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                         LEFT JOIN {{WiserTableNames.WiserUserRoles}} user_role ON user_role.user_id = ?userId
-                                        LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                        LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                         {filters}
                                         WHERE [if({title}!)]i.title {title_filter}[else]TRUE[endif] 
@@ -564,7 +564,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                          # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                          LEFT JOIN {{WiserTableNames.WiserUserRoles}} user_role ON user_role.user_id = ?userId
-                                         LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                         LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                          {filters}
                                          WHERE [if({title}!)]i.title {title_filter}[else]TRUE[endif] 
@@ -596,7 +596,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                       # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                       LEFT JOIN {WiserTableNames.WiserUserRoles} user_role ON user_role.user_id = ?userId
-                                      LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                      LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                       WHERE i.title LIKE CONCAT(?search, '%')
                                       {versionWhereClause}
@@ -614,7 +614,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                       # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                       LEFT JOIN {WiserTableNames.WiserUserRoles} user_role ON user_role.user_id = ?userId
-                                      LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                      LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                       WHERE id.`value` LIKE CONCAT(?search, '%')
                                       {versionWhereClause}
@@ -641,7 +641,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                    # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                    LEFT JOIN {WiserTableNames.WiserUserRoles} user_role ON user_role.user_id = ?userId
-                                   LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                   LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                    WHERE i.title LIKE CONCAT(?search, '%')
                                    {versionWhereClause}
@@ -660,7 +660,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
                                        i.added_by AS addedby,
                                        e.icon,
                                        e.color,
-                                       ' AS moreInfo
+                                       '' AS moreInfo
                                    FROM {tablePrefix}{WiserTableNames.WiserItemDetail} id
                                    JOIN {tablePrefix}{WiserTableNames.WiserItem} i ON i.id = id.item_id AND (?entityType = '' OR i.entity_type = ?entityType)
                                    JOIN {WiserTableNames.WiserEntity} e ON e.name = i.entity_type AND e.show_in_search = 1
@@ -669,7 +669,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                    # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                    LEFT JOIN {WiserTableNames.WiserUserRoles} user_role ON user_role.user_id = ?userId
-                                   LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                   LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                    WHERE id.`value` LIKE CONCAT(?search, '%')
                                    {versionWhereClause}
@@ -691,7 +691,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                        # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                        LEFT JOIN {WiserTableNames.WiserUserRoles} user_role ON user_role.user_id = ?userId
-                                       LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                       LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                        WHERE i.title LIKE CONCAT(?search, '%')
                                        {versionWhereClause}
@@ -709,7 +709,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                        # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                        LEFT JOIN {WiserTableNames.WiserUserRoles} user_role ON user_role.user_id = ?userId
-                                       LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                       LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                        WHERE id.`value` LIKE CONCAT(?search, '%')
                                        {versionWhereClause}
@@ -717,7 +717,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
                                        GROUP BY i.id
                                        """;
 
-                        selectQuery = $"""
+                        selectQuery += $"""
 
                                        UNION
 
@@ -739,7 +739,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                        # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                        LEFT JOIN {WiserTableNames.WiserUserRoles} user_role ON user_role.user_id = ?userId
-                                       LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                       LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                        WHERE i.title LIKE CONCAT(?search, '%')
                                        {versionWhereClause}
@@ -767,7 +767,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                        # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                        LEFT JOIN {WiserTableNames.WiserUserRoles} user_role ON user_role.user_id = ?userId
-                                       LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                       LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                        WHERE id.`value` LIKE CONCAT(?search, '%')
                                        {versionWhereClause}
@@ -1139,7 +1139,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                            # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                               LEFT JOIN {{WiserTableNames.WiserUserRoles}} user_role ON user_role.user_id = ?userId
-                                              LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                              LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                            WHERE i.entity_type = ?entityType
                                            AND i.published_environment >= 0
@@ -1159,7 +1159,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                            # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                               LEFT JOIN {{WiserTableNames.WiserUserRoles}} user_role ON user_role.user_id = ?userId
-                                              LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                              LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                            WHERE i.entity_type = ?entityType
                                            AND i.published_environment >= 0
@@ -1202,7 +1202,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                             # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                             LEFT JOIN {{WiserTableNames.WiserUserRoles}} user_role ON user_role.user_id = ?userId
-                                            LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                            LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
                                             
                                             WHERE i.entity_type = ?entityType
                                             AND i.published_environment >= 0
@@ -1246,7 +1246,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                            # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                            LEFT JOIN {{WiserTableNames.WiserUserRoles}} user_role ON user_role.user_id = ?userId
-                                           LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                           LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                            WHERE i.parent_item_id = ?itemId
                                            {{(String.IsNullOrEmpty(entityType) ? "" : "AND FIND_IN_SET(i.entity_type, ?entityType)")}}
@@ -1287,7 +1287,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                             # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                             LEFT JOIN {{WiserTableNames.WiserUserRoles}} user_role ON user_role.user_id = ?userId
-                                            LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                            LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                             LEFT JOIN {{WiserTableNames.WiserEntityProperty}} p ON p.entity_name = i.entity_type AND p.visible_in_overview = 1
                                             LEFT JOIN {{tablePrefix}}{{WiserTableNames.WiserItemDetail}} id ON id.item_id = i.id AND ((p.property_name IS NOT NULL AND p.property_name <> '' AND id.`key` IN(p.property_name, CONCAT(p.property_name, '_input'))) OR ((p.property_name IS NULL OR p.property_name = '') AND id.`key` IN(p.display_name, CONCAT(p.property_name, '_input'))))
@@ -1315,7 +1315,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                            # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                            LEFT JOIN {{WiserTableNames.WiserUserRoles}} user_role ON user_role.user_id = ?userId
-                                           LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                           LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                            WHERE il.{{(currentItemIsSourceId ? "item_id" : "destination_item_id")}} = ?itemId
                                            {{versionWhereClause}}
@@ -1356,7 +1356,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                             # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                             LEFT JOIN {{WiserTableNames.WiserUserRoles}} user_role ON user_role.user_id = ?userId
-                                            LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                            LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                             LEFT JOIN {{WiserTableNames.WiserEntityProperty}} p ON p.entity_name = i.entity_type AND p.visible_in_overview = 1
                                             LEFT JOIN {{tablePrefix}}{{WiserTableNames.WiserItemDetail}} id ON id.item_id = il.item_id AND ((p.property_name IS NOT NULL AND p.property_name <> '' AND id.`key` IN(p.property_name, CONCAT(p.property_name, '_input'))) OR ((p.property_name IS NULL OR p.property_name = '') AND id.`key` IN(p.display_name, CONCAT(p.property_name, '_input')))) AND id.language_code = p.language_code
@@ -1401,7 +1401,7 @@ public class GridsService(IItemsService itemsService, IWiserTenantsService wiser
 
                                             # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                             LEFT JOIN {{WiserTableNames.WiserUserRoles}} user_role ON user_role.user_id = ?userId
-                                            LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id
+                                            LEFT JOIN {{WiserTableNames.WiserPermission}} permission ON permission.role_id = user_role.role_id AND permission.item_id = i.id AND (permission.entity_name = i.entity_type OR permission.entity_name = '')
 
                                             JOIN {{WiserTableNames.WiserEntityProperty}} p ON p.link_type = il.type AND p.visible_in_overview = 1
                                             JOIN {{linkTablePrefix}}{{WiserTableNames.WiserItemLinkDetail}} id ON id.itemlink_id = il.id AND ((p.property_name IS NOT NULL AND p.property_name <> '' AND id.`key` IN(p.property_name, CONCAT(p.property_name, '_input'))) OR ((p.property_name IS NULL OR p.property_name = '') AND id.`key` IN(p.display_name, CONCAT(p.property_name, '_input')))) AND id.language_code = p.language_code

--- a/Api/Modules/Items/Services/ItemsService.cs
+++ b/Api/Modules/Items/Services/ItemsService.cs
@@ -146,7 +146,7 @@ public class ItemsService(
                           
                                                           # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                           	                            LEFT JOIN {WiserTableNames.WiserUserRoles} user_role ON user_role.user_id = ?userId
-                          	                            LEFT JOIN {WiserTableNames.WiserPermission} permission_item ON permission_item.role_id = user_role.role_id AND permission_item.item_id = item.id
+                          	                            LEFT JOIN {WiserTableNames.WiserPermission} permission_item ON permission_item.role_id = user_role.role_id AND permission_item.item_id = item.id AND (permission_item.entity_name = item.entity_type OR permission_item.entity_name = '')
                                                           LEFT JOIN {WiserTableNames.WiserPermission} permission_module ON permission_module.role_id = user_role.role_id AND permission_module.module_id = item.moduleid
                           
                                                           WHERE item.published_environment >= 1
@@ -212,7 +212,7 @@ public class ItemsService(
                      
                                          # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                      	                LEFT JOIN {WiserTableNames.WiserUserRoles} user_role ON user_role.user_id = ?userId
-                     	                LEFT JOIN {WiserTableNames.WiserPermission} permission_item ON permission_item.role_id = user_role.role_id AND permission_item.item_id = item.id
+                     	                LEFT JOIN {WiserTableNames.WiserPermission} permission_item ON permission_item.role_id = user_role.role_id AND permission_item.item_id = item.id AND (permission_item.entity_name = item.entity_type OR permission_item.entity_name = '')
                                          LEFT JOIN {WiserTableNames.WiserPermission} permission_module ON permission_module.role_id = user_role.role_id AND permission_module.module_id = item.moduleid
                      
                                          WHERE item.published_environment >= 1
@@ -2281,7 +2281,7 @@ public class ItemsService(
 
                      # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                      LEFT JOIN {WiserTableNames.WiserUserRoles} AS user_role ON user_role.user_id = ?userId
-                     LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = user_role.role_id AND permission.item_id = item.id
+                     LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = user_role.role_id AND permission.item_id = item.id AND (permission.entity_name = item.entity_type OR permission.entity_name = '')
 
                      # Only get items that should actually be shown, based on accepted_childtypes from wiser_entity.
                      LEFT JOIN {parentTablePrefix}{WiserTableNames.WiserItem} parent_item ON parent_item.id = link_parent.destination_item_id
@@ -2360,7 +2360,7 @@ public class ItemsService(
 
                      # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                      LEFT JOIN {WiserTableNames.WiserUserRoles} AS user_role ON user_role.user_id = ?userId
-                     LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = user_role.role_id AND permission.item_id = item.id
+                     LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = user_role.role_id AND permission.item_id = item.id AND (permission.entity_name = item.entity_type OR permission.entity_name = '')
 
                      # Only get items that should actually be shown, based on accepted_childtypes from wiser_entity.
                      LEFT JOIN {parentTablePrefix}{WiserTableNames.WiserItem} parent_item ON parent_item.id = item.parent_item_id
@@ -2425,7 +2425,7 @@ public class ItemsService(
                  
                                      # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                      LEFT JOIN {WiserTableNames.WiserUserRoles} AS user_role ON user_role.user_id = ?userId
-                                     LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = user_role.role_id AND permission.item_id = child.id
+                                     LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = user_role.role_id AND permission.item_id = child.id AND (permission.entity_name = child.entity_type OR permission.entity_name = '')
                  
                                      WHERE item.id IN ({String.Join(",", results.Select(i => i.PlainItemId))})
                                      AND item.moduleid = ?moduleId
@@ -3007,7 +3007,7 @@ public class ItemsService(
 
                      # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                      LEFT JOIN {WiserTableNames.WiserUserRoles} AS userRole ON userRole.user_id = ?userId
-                     LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = userRole.role_id AND permission.item_id = item.id
+                     LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = userRole.role_id AND permission.item_id = item.id AND (permission.entity_name = item.entity_type OR permission.entity_name = '')
 
                      WHERE (permission.id IS NULL OR (permission.permissions & 1) > 0)
                      AND item.entity_type = ?entityType

--- a/Api/Modules/Items/Services/ItemsService.cs
+++ b/Api/Modules/Items/Services/ItemsService.cs
@@ -1927,7 +1927,7 @@ public class ItemsService(
                       
                                               # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                               LEFT JOIN {{WiserTableNames.WiserUserRoles}} AS user_role ON user_role.user_id = ?userId
-                                              LEFT JOIN {{WiserTableNames.WiserPermission}} AS permission ON permission.role_id = user_role.role_id AND permission.item_id = item.id
+                                              LEFT JOIN {{WiserTableNames.WiserPermission}} AS permission ON permission.role_id = user_role.role_id AND permission.item_id = item.id AND (permission.entity_name = item.entity_type OR permission.entity_name = '')
                       
                                               WHERE item.id = ?itemId
                                               AND (permission.id IS NULL OR (permission.permissions & 1) > 0)


### PR DESCRIPTION
# Describe your changes

Allow permissions for items to be applied to specific entities. This fixes the problem that if permissions are set this is applied to entities in wiser_item and any prefix table with the same ID.

For backwards compatibility, if no entity type is provided with the permission it still applies to all items with the same ID.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by adding a permission for an item and validated the correct behavior if no entity type has been provided, if the entity type of the item in `wiser_item` was provided and the entity type of the item in the prefix table.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable
- [ ] I added my change to the release notes of the dashboard module, if this is useful to know for our customers.

# Related pull requests

https://github.com/happy-geeks/geeks-core-library/pull/857
Wiser update is not dependent on the GCL update, but will not apply the new functionality until a new GCL version is matched.

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1205090868730163/task/1209869916047907