### PR TITLE
add missing column to creation system

### DIFF
--- a/Api/Core/Queries/WiserInstallation/CreateTables.sql
+++ b/Api/Core/Queries/WiserInstallation/CreateTables.sql
@@ -502,6 +502,7 @@ CREATE TABLE IF NOT EXISTS `wiser_user_roles`  (
   `id` int NOT NULL AUTO_INCREMENT,
   `user_id` int NOT NULL,
   `role_id` int NOT NULL,
+  `ip_addresses` json NULL,
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE INDEX `idx_user_id`(`user_id`, `role_id`) USING BTREE
 ) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = Dynamic;


### PR DESCRIPTION
# Describe your changes

the create table sql is missing a column, halting the creation process of new tenants once again.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
