### PR TITLE
remove a function that is not useful for the multi StyledOutputServic…

### DIFF
--- a/Api/Modules/Queries/Services/StyledOutputService.cs
+++ b/Api/Modules/Queries/Services/StyledOutputService.cs
@@ -775,12 +775,6 @@ public class StyledOutputService : IStyledOutputService, IScopedService
 
             builder.Append(itemValue);
 
-            if (i != dataTable.Rows.Count - 1)
-            {
-                builder.Append(ItemSeparatorString);
-            }
-
-
             if (!String.IsNullOrWhiteSpace(style.FormatEnd))
             {
                 var formattedEnd = stringReplacementsService.DoReplacements(style.FormatEnd, result[i]);


### PR DESCRIPTION

# Describe your changes
remove a function that is not useful for the multi StyledOutputService parsing causing trailing comma's to appear


## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

locally routed to I

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [not yet] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [] I added new unit tests for my changes if applicable
- [] I added my change to the release notes of the dashboard module, if this is useful to know for our customers.

# Related pull requests
none

# Link to Asana ticket

none