### PR TITLE
Add support for "1" and "0" values for isEnabled check in Products API

### DIFF
--- a/Api/Modules/Products/Services/ProductsService.cs
+++ b/Api/Modules/Products/Services/ProductsService.cs
@@ -894,14 +894,16 @@ ON DUPLICATE KEY UPDATE id=id;
     /// </summary>
     private async Task<bool> IsProductsApiEnabledAsync()
     {
-        var isEnabled = await GetGlobalSettingAsync(ProductsServiceConstants.PropertyProductsApiEnabled);
-        if (isEnabled == null)
+        var isEnabledValue = await GetGlobalSettingAsync(ProductsServiceConstants.PropertyProductsApiEnabled);
+        
+        return isEnabledValue switch
         {
             // No settings can be found, so it must be disabled.
-            return false;
-        }
-
-        // We have settings but what are they set to?
-        return bool.TryParse(isEnabled, out var enabled) && enabled;
+            null => false,
+            "1" => true,
+            "0" => false,
+            // If it's not 1 or 0, we try to parse it as a boolean.
+            _ => Boolean.TryParse(isEnabledValue, out var isEnabled) && isEnabled
+        };
     }
 }


### PR DESCRIPTION
# Describe your changes

Wiser checkboxes use "1" and "0" depending on check state bool.Parse gives a formatException for these values so this now gets checked explicitly.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Called the products API refresh, which contains the isEnabled check.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable
- [ ] I added my change to the release notes of the dashboard module, if this is useful to know for our customers.

# Related pull requests

N/A

# Link to Asana ticket

N/A
