### PR TITLE
Replace MySQL NOW() with DateTime.Now for consistent server-side time handling

### DIFF
--- a/Api/Modules/Products/Services/ProductsService.cs
+++ b/Api/Modules/Products/Services/ProductsService.cs
@@ -270,17 +270,17 @@ public class ProductsService(
             throw new KeyNotFoundException(errorMsg);
         }
 
-        var coolDown = await GetGlobalSettingAsync(ProductsServiceConstants.PropertyMinimalRefreshCoolDown);
-        if (coolDown == null)
+        var coolDownParsed = int.TryParse(await GetGlobalSettingAsync(ProductsServiceConstants.PropertyMinimalRefreshCoolDown), out var coolDown);
+        if (!coolDownParsed)
         {
-            var errorMsg = "Wiser product api cannot find the cool down setting for the product api.";
+            var errorMsg = "Invalid cool down setting used for the product api.";
             logger.LogError(errorMsg);
-            throw new KeyNotFoundException(errorMsg);
+            throw new ProductsApiException(errorMsg);
         }
 
         var coolDownString = ignoreCoolDown
             ? ""
-            : $"AND (apis.refresh_date < DATE_SUB(NOW(), INTERVAL {coolDown} MINUTE) OR apis.refresh_date IS NULL)";
+            : $"AND (apis.refresh_date < DATE_SUB(?date, INTERVAL ?coolDown MINUTE) OR apis.refresh_date IS NULL)";
 
         var getApiDataQuery = $"""
                                SELECT 
@@ -312,6 +312,9 @@ public class ProductsService(
                                LIMIT 256
                                """;
         await clientDatabaseConnection.EnsureOpenConnectionForReadingAsync();
+        
+        clientDatabaseConnection.AddParameter("date",  DateTime.Now);
+        clientDatabaseConnection.AddParameter("coolDown",  coolDown);
         var dataTable = await clientDatabaseConnection.GetAsync(getApiDataQuery);
 
         var generatedData = new List<ProductApiModel>();
@@ -728,16 +731,14 @@ ON DUPLICATE KEY UPDATE id=id;
         }
 
         // if we dont have a date, take now
-        date ??= DateTime.Now.Date;
-
-        var sqlDate = date.Value.ToString("yyyy-MM-dd HH:mm:ss");
-
-        var coolDown = await GetGlobalSettingAsync(ProductsServiceConstants.PropertyMinimalRefreshCoolDown);
-        if (coolDown == null)
+        date ??= DateTime.Now;
+        
+        var coolDownParsed = int.TryParse(await GetGlobalSettingAsync(ProductsServiceConstants.PropertyMinimalRefreshCoolDown), out var coolDown);
+        if (!coolDownParsed)
         {
-            var errorMsg = "Wiser product api cannot find the cool down setting for the product api.";
+            var errorMsg = "Invalid cool down setting used for the product api.";
             logger.LogError(errorMsg);
-            throw new KeyNotFoundException(errorMsg);
+            throw new ProductsApiException(errorMsg);
         }
 
         // Now that we have all ids, check how many are out of date for the given date.
@@ -757,10 +758,12 @@ ON DUPLICATE KEY UPDATE id=id;
                                LEFT JOIN {WiserTableNames.WiserProductsApi} apis ON apis.wiser_id = item.id AND apis.version = latest_version.max_version 
                                 
                                WHERE item.entity_type = '{productEntityType}' 
-                                 AND (apis.refresh_date < DATE_SUB("{sqlDate}", INTERVAL {coolDown} MINUTE) OR apis.refresh_date IS NULL)
+                                 AND (apis.refresh_date < DATE_SUB(?date, INTERVAL ?coolDown MINUTE) OR apis.refresh_date IS NULL)
                                  AND item.id IN ({productsQuery.TrimEnd(';')})
                                """;
 
+        clientDatabaseConnection.AddParameter("date",  date);
+        clientDatabaseConnection.AddParameter("coolDown",  coolDown);
         var dataTableOutOfData = await clientDatabaseConnection.GetAsync(getOutofDateQuery);
 
         return new ServiceResult<JToken>


### PR DESCRIPTION
Update GetOutOfDateCountAsync() to use DateTime.Now instead of DateTime.Now.Date to ensure correct cooldown calculation. 
Move cooldown and date values into parameterized queries to avoid string injection and improve safety.

# Describe your changes

Fix incorrect cooldown calculations in GetOutOfDateCountAsync().

The ProductsService used DateTime.Now.Date as the fallback timestamp when checking whether the last refresh exceeded the cooldown period. Because the time component was reset to 00:00:00, this produced inconsistent results and undercounted products.

The method now uses DateTime.Now so the full timestamp is preserved and the cooldown logic produces accurate counts.


Also moved cooldown and date values into parameterized queries to avoid string injection and improve safety.
 

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Manually tested by using Postman to call the `api/v3/products/count-outdated-products` and `api/v3/products/refresh-all` endpoints and check their results.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable
- [ ] I added my change to the release notes of the dashboard module, if this is useful to know for our customers.

# Related pull requests


# Link to Asana ticket
