### PR TITLE
Bugfix/tree view performance

### DIFF
--- a/Api/Modules/Items/Services/ItemsService.cs
+++ b/Api/Modules/Items/Services/ItemsService.cs
@@ -2444,7 +2444,7 @@ public class ItemsService(
                                      JOIN {WiserTableNames.WiserEntity} AS entity ON entity.name = item.entity_type AND entity.show_in_tree_view = 1
                  
                                      JOIN {WiserTableNames.WiserItemLink} link_child ON link_child.destination_item_id = item.id AND link_child.type NOT IN ({linkTypesToHideFromTreeViewList})
-                                     JOIN {childPrefix}{WiserTableNames.WiserItem} AS child ON child.id = link_child.item_id AND child.moduleid = ?moduleId AND (?childEntityTypes = '' OR FIND_IN_SET(child.entity_type, ?childEntityTypes))
+                                     JOIN {childPrefix}{WiserTableNames.WiserItem} AS child FORCE INDEX (PRIMARY) ON child.id = link_child.item_id AND child.moduleid = ?moduleId AND (?childEntityTypes = '' OR FIND_IN_SET(child.entity_type, ?childEntityTypes))
                                      JOIN {WiserTableNames.WiserEntity} AS child_entity ON child_entity.name = child.entity_type AND child_entity.show_in_tree_view = 1 AND (entity.accepted_childtypes = '' OR FIND_IN_SET(child.entity_type, entity.accepted_childtypes))
                  
                                      # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.

--- a/FrontEnd/Modules/Dashboard/Views/Dashboard/Index.cshtml
+++ b/FrontEnd/Modules/Dashboard/Views/Dashboard/Index.cshtml
@@ -142,6 +142,12 @@
                         <a class="k-button k-button-flat-base k-button-flat k-button-md k-rounded-md k-icon-button k-close-button"><span class="k-button-icon k-icon k-i-close"></span></a>
                         <div class="tile-content" data-tile="updateLog">
                             <div class="log-item">
+                                <h4>Versie 3.7.261.1 - 19 Januari 2026</h4>
+                                <ul>
+                                  <li><ins class="icon-check"></ins><span>Los probleem op met langzaam laden van boomstructuren in specifieke omgevingen.</span></li>
+                                </ul>
+                            </div>
+                            <div class="log-item">
                                 <h4>Versie 3.7.2512.1 - 8 december 2025</h4>
                                 <ul>
                                   <li><ins class="icon-check"></ins><span>Products API: Probleem opgelost met het berekenen van het aantal te refreshen producten.</span></li>

--- a/FrontEnd/Modules/Dashboard/Views/Dashboard/Index.cshtml
+++ b/FrontEnd/Modules/Dashboard/Views/Dashboard/Index.cshtml
@@ -142,7 +142,7 @@
                         <a class="k-button k-button-flat-base k-button-flat k-button-md k-rounded-md k-icon-button k-close-button"><span class="k-button-icon k-icon k-i-close"></span></a>
                         <div class="tile-content" data-tile="updateLog">
                             <div class="log-item">
-                                <h4>Versie 3.7.261.1 - 19 Januari 2026</h4>
+                                <h4>Versie 3.7.2601.1 - 19 Januari 2026</h4>
                                 <ul>
                                   <li><ins class="icon-check"></ins><span>Los probleem op met langzaam laden van boomstructuren in specifieke omgevingen.</span></li>
                                 </ul>


### PR DESCRIPTION
# Describe your changes

Fix issue where some treeviews would load very slowly because in this query it would use the moduleid index instead of the primary which is guaranteed to be faster in this case.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

The query change was analysed using the mysql EXPLAIN function and tested in a treeview in a Wiser environment

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable
- [x] I added my change to the release notes of the dashboard module, if this is useful to know for our customers.

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1151477971646641/task/1212474845063399?focus=true