### PR TITLE
Feature/product refresh ignore cooldown

### DIFF
--- a/Api/Modules/Products/Controllers/ProductsController.cs
+++ b/Api/Modules/Products/Controllers/ProductsController.cs
@@ -69,15 +69,16 @@ public class ProductsController : ControllerBase
     /// Refresh the product api result, this function updates the product api result but only 1.
     /// </summary>
     /// <param name="wiserId">the id of the wiser product we are trying to read.</param>
+    /// <param name="ignoreCooldown">Whether to ignore the cooldown (minimum time since last refresh)</param>
     /// <returns></returns>
     [HttpPost]
     [Route("refresh/{wiserId:int:required}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> RefreshAsync(ulong wiserId)
+    public async Task<IActionResult> RefreshAsync(ulong wiserId, [FromQuery] bool ignoreCooldown = false)
     {
-        return (await productsService.RefreshProductAsync((ClaimsIdentity) User.Identity, wiserId)).GetHttpResponseMessage();
+        return (await productsService.RefreshProductAsync((ClaimsIdentity) User.Identity, wiserId, ignoreCooldown)).GetHttpResponseMessage();
     }
 
     /// <summary>

--- a/FrontEnd/Modules/Dashboard/Views/Dashboard/Index.cshtml
+++ b/FrontEnd/Modules/Dashboard/Views/Dashboard/Index.cshtml
@@ -141,6 +141,12 @@
                     <script id="update-log" type="text/x-kendo-template">
                         <a class="k-button k-button-flat-base k-button-flat k-button-md k-rounded-md k-icon-button k-close-button"><span class="k-button-icon k-icon k-i-close"></span></a>
                         <div class="tile-content" data-tile="updateLog">
+                             <div class="log-item">
+                                <h4>Versie 3.7.2603.1 - 3 Maart 2026</h4>
+                                <ul>
+                                  <li><ins class="icon-check"></ins><span>Products API: Voeg ondersteuning toe voor negeren cooldown tijd bij verversen van producten</span></li>
+                                </ul>
+                            </div>
                             <div class="log-item">
                                 <h4>Versie 3.7.2601.1 - 28 Januari 2026</h4>
                                 <ul>


### PR DESCRIPTION
# Describe your changes

Adds possibility to pass in an ignoreCooldown so products can be manually refreshed at any time without having to wait for the refresh cooldown.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Passed in ignoreCooldown as parameter and tested with a product that was still within the cooldown period.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable
- [x] I added my change to the release notes of the dashboard module, if this is useful to know for our customers.

# Related pull requests

N/A

# Link to Asana ticket

N/A